### PR TITLE
Add additional fields to info blocks

### DIFF
--- a/app/src/main/java/org/dharmaseed/android/CenterCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/CenterCursorAdapter.java
@@ -47,6 +47,10 @@ public class CenterCursorAdapter extends StarCursorAdapter {
         TextView title=(TextView)view.findViewById(R.id.item_view_title);
         title.setText(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Center.NAME)).trim());
 
+        // Get number of talks by this center
+        TextView numTalks=(TextView)view.findViewById(R.id.item_view_detail1);
+        numTalks.setText(cursor.getString(cursor.getColumnIndexOrThrow("talk_count")) + " talks");
+
         // Set photo
         ImageView photoView = (ImageView) view.findViewById(R.id.item_view_photo);
         Drawable icon = ContextCompat.getDrawable(context, R.drawable.dharmaseed_icon);

--- a/app/src/main/java/org/dharmaseed/android/CenterCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/CenterCursorAdapter.java
@@ -43,10 +43,9 @@ public class CenterCursorAdapter extends StarCursorAdapter {
     public void bindView(View view, Context context, Cursor cursor) {
 
         // Set center name
+        clearView(view);
         TextView title=(TextView)view.findViewById(R.id.item_view_title);
-        TextView subtitle=(TextView)view.findViewById(R.id.item_view_subtitle);
         title.setText(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Center.NAME)).trim());
-        subtitle.setText("");
 
         // Set photo
         ImageView photoView = (ImageView) view.findViewById(R.id.item_view_photo);

--- a/app/src/main/java/org/dharmaseed/android/CenterRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/CenterRepository.java
@@ -29,7 +29,12 @@ public class CenterRepository extends Repository {
      */
     public Cursor getCenters(List<String> searchTerms, boolean isStarred)
     {
-        String query = "SELECT centers._id, centers.name FROM centers ";
+        String query = "SELECT centers._id, centers.name, count(talks._id) AS talk_count FROM centers ";
+        query += innerJoin(
+                DBManager.C.Talk.TABLE_NAME,
+                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.VENUE_ID,
+                DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.ID
+        );
 
         if (isStarred)
         {
@@ -47,7 +52,7 @@ public class CenterRepository extends Repository {
             where += " AND " + getSearchStatement(searchTerms, selectionColumns);
         }
 
-        query += where + " ORDER BY centers.name ASC";
+        query += where + "GROUP BY centers._id ORDER BY centers.name ASC";
 
         return queryIfNotNull(query, null);
     }

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -24,6 +24,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import org.json.JSONException;
@@ -464,5 +465,16 @@ public class DBManager extends SQLiteOpenHelper {
         }
         cursor.close();
         return outOfDate;
+    }
+
+    /**
+     * Get an alias for a fully qualified column name. This is useful in naming columns in a query
+     * using SQL AS clauses and referencing them later
+     * @param fullyQualifiedColumn Name of the column with the table name prepended (i.e. "talks.title")
+     * @return The alias for this column
+     */
+    @NonNull
+    public static String getAlias(String fullyQualifiedColumn) {
+        return fullyQualifiedColumn.replace(".", "_");
     }
 }

--- a/app/src/main/java/org/dharmaseed/android/StarCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/StarCursorAdapter.java
@@ -27,6 +27,7 @@ import android.support.v4.widget.CursorAdapter;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.TextView;
 
 /**
  * Created by bbethke on 5/15/16.
@@ -81,5 +82,14 @@ public abstract class StarCursorAdapter extends CursorAdapter {
             }
         });
 
+    }
+
+    void clearView(View view) {
+        int ids[] = {R.id.item_view_title, R.id.item_view_detail1, R.id.item_view_detail2,
+                R.id.item_view_detail3, R.id.item_view_detail4};
+        for(int id : ids) {
+            TextView textView=(TextView)view.findViewById(id);
+            textView.setText("");
+        }
     }
 }

--- a/app/src/main/java/org/dharmaseed/android/TalkRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkRepository.java
@@ -8,18 +8,26 @@ import android.util.Log;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TalkRepository extends Repository
-{
+public class TalkRepository extends Repository {
 
     private static final String LOG_TAG = "TalkRepository";
+    private DBManager dbManager;
+    private List<String> talkAdapterColumns;
 
-    public TalkRepository(SQLiteOpenHelper dbManager)
-    {
+    public TalkRepository(SQLiteOpenHelper dbManager) {
         super(dbManager);
+
+        talkAdapterColumns = new ArrayList<String>();
+        talkAdapterColumns.add(DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.ID);
+        talkAdapterColumns.add(DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.TITLE);
+        talkAdapterColumns.add(DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.TEACHER_ID);
+        talkAdapterColumns.add(DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.NAME);
+        talkAdapterColumns.add(DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.NAME);
+        talkAdapterColumns.add(DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.DURATION_IN_MINUTES);
+        talkAdapterColumns.add(DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.RECORDING_DATE);
     }
 
     /**
-     *
      * @param searchTerms
      * @param isStarred
      * @param isDownloaded
@@ -29,109 +37,123 @@ public class TalkRepository extends Repository
             List<String> searchTerms,
             boolean isStarred,
             boolean isDownloaded
-    )
-    {
-        List<String> columns = new ArrayList<>();
-        columns.add(DBManager.C.Talk.TABLE_NAME    + "." + DBManager.C.Talk.ID);
-        columns.add(DBManager.C.Talk.TABLE_NAME    + "." + DBManager.C.Talk.TITLE);
-        columns.add(DBManager.C.Talk.TABLE_NAME    + "." + DBManager.C.Talk.TEACHER_ID);
-        columns.add(DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.NAME);
-        return getTalks(columns, searchTerms, isStarred, isDownloaded);
+    ) {
+        return getTalks(talkAdapterColumns, searchTerms, isStarred, isDownloaded, "");
     }
 
     /**
-     * @param columns the columns to select or null if all
-     * @param searchTerms the term to filter by or null if none
-     * @param isStarred whether the talk is starred
+     * @param columns      list of fully-qualified column names (i.e. "talks.title") to return from the query
+     *                     columns returned in the cursor will be aliased; use DBManager.getAlias to convert
+     *                     a fully-qualified column name to its alias
+     * @param searchTerms  the term to filter by or null if none
+     * @param isStarred    whether the talk is starred
      * @param isDownloaded whether the talk is downloaded
+     * @param extraWhere   an extra where clause that can be used to filter on a specific teacher/center id
      * @return every talk in the db filtered by search term, is starred, and is downloaded
      */
     public Cursor getTalks(
-           List<String> columns,
-           List<String> searchTerms,
-           boolean isStarred,
-           boolean isDownloaded
-    )
-    {
+            List<String> columns,
+            List<String> searchTerms,
+            boolean isStarred,
+            boolean isDownloaded,
+            String extraWhere
+    ) {
+        if (columns == null || columns.size() == 0) {
+            throw new IllegalArgumentException("No columns were specified; at least one is required");
+        }
+
         String queryColumns = "";
-        if (columns == null || columns.size() == 0)
-        {
-            queryColumns = "*";
+        List<String> namedColumns = new ArrayList<String>();
+
+        // Note: we must always have a column called _id in order to use the returned cursor
+        // with the CursorAdapter class
+        namedColumns.add(DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.ID + " AS _id");
+        for (String column : columns) {
+            namedColumns.add(column + " AS " + DBManager.getAlias(column));
         }
-        else
-        {
-            queryColumns = TextUtils.join(", ", columns);
-        }
+        queryColumns = TextUtils.join(", ", namedColumns);
 
         String query = "SELECT " + queryColumns + " FROM " + DBManager.C.Talk.TABLE_NAME;
 
         String innerJoin = "";
 
-        boolean teachers = false;
-        if (queryColumns.contains(DBManager.C.Teacher.TABLE_NAME))
-        {
+        boolean teachers = false, centers = false;
+        if (queryColumns.contains(DBManager.C.Teacher.TABLE_NAME)) {
             teachers = true;
             innerJoin += joinTalkIdTeacherId();
         }
+        if (queryColumns.contains(DBManager.C.Center.TABLE_NAME)) {
+            centers = true;
+            innerJoin += joinTalkIdVenueId();
+        }
 
-        if (isStarred)
-        {
+        if (isStarred) {
             innerJoin += joinStarredTalks();
         }
 
-        if (isDownloaded)
-        {
+        if (isDownloaded) {
             innerJoin += joinDownloadedTalks();
         }
 
         String where = "";
-        if (searchTerms != null && searchTerms.size() > 0)
-        {
+        if (searchTerms != null && searchTerms.size() > 0) {
             // get the teachers table if we haven't already
-            if (!teachers)
-            {
+            if (!teachers) {
                 innerJoin += joinTalkIdTeacherId();
             }
 
-            // we only need the center table if we have search terms
-            innerJoin += innerJoin(
-                    DBManager.C.Center.TABLE_NAME,
-                    DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.ID,
-                    DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.VENUE_ID
-            );
+            // get the centers table if we haven't already
+            if (!centers) {
+                innerJoin += joinTalkIdVenueId();
+            }
 
             String[] selectionColumns = new String[]
-            {
-                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.TITLE,
-                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.DESCRIPTION,
-                DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.NAME,
-                DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.NAME
-            };
+                    {
+                            DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.TITLE,
+                            DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.DESCRIPTION,
+                            DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.NAME,
+                            DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.NAME
+                    };
 
             where += getSearchStatement(searchTerms, selectionColumns);
         }
 
-        if (!innerJoin.isEmpty())
-        {
+        if (!innerJoin.isEmpty()) {
             query += innerJoin;
         }
 
-        if (!where.isEmpty())
-        {
-            query += " WHERE " + where;
+        List<String> whereClauses = new ArrayList<String>();
+        if (!where.isEmpty()) {
+            whereClauses.add(where);
+        }
+        if (!extraWhere.isEmpty()) {
+            whereClauses.add(extraWhere);
+        }
+        String fullWhere = TextUtils.join(" AND ", whereClauses);
+        if (!fullWhere.isEmpty()) {
+            query += " WHERE " + fullWhere;
         }
 
         query += " ORDER BY "
                 + DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.RECORDING_DATE
                 + " DESC"
-                ;
+        ;
         Log.d(LOG_TAG, query);
         return queryIfNotNull(query, null);
     }
 
+    public Cursor getTalks(
+            List<String> columns,
+            List<String> searchTerms,
+            boolean isStarred,
+            boolean isDownloaded
+    ) {
+        return getTalks(columns, searchTerms, isStarred, isDownloaded, "");
+    }
+
     /**
      * @param searchTerms
-     * @param teacherId the teacher id
+     * @param teacherId    the teacher id
      * @param isStarred
      * @param isDownloaded
      * @return all talks with by a teacher
@@ -141,49 +163,12 @@ public class TalkRepository extends Repository
             long teacherId,
             boolean isStarred,
             boolean isDownloaded
-    )
-    {
-        String query = "SELECT talks._id, talks.title, talks.teacher_id, teachers.name, talks.rec_date FROM talks";
-
-        if (isStarred)
-        {
-            query += joinStarredTalks();
-        }
-
-        if (isDownloaded)
-        {
-            query += joinDownloadedTalks();
-        }
-
-        query += joinTalkIdTeacherId();
-
-        String where = " WHERE ";
-
-        if (searchTerms != null && !searchTerms.isEmpty())
-        {
-            String[] selectionColumns = new String[]
-            {
-                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.TITLE,
-                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.DESCRIPTION,
-            };
-
-            where += getSearchStatement(searchTerms, selectionColumns) + " AND ";
-        }
-
-        where += String.format(
-                " %s.%s = %s ",
-                DBManager.C.Talk.TABLE_NAME,
-                DBManager.C.Talk.TEACHER_ID,
-                teacherId
-        );
-
-        query += where + " ORDER BY talks.rec_date DESC ";
-
-        return queryIfNotNull(query, null);
+    ) {
+        return getTalks(talkAdapterColumns, searchTerms, isStarred, isDownloaded,
+                DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.ID + "=" + teacherId);
     }
 
     /**
-     *
      * @param searchTerms
      * @param venueId
      * @param isStarred
@@ -195,50 +180,13 @@ public class TalkRepository extends Repository
             long venueId,
             boolean isStarred,
             boolean isDownloaded
-    )
-    {
-        String query = "SELECT talks._id, talks.title, talks.teacher_id, centers.name, talks.rec_date FROM talks";
-
-        if (isStarred)
-        {
-            query += joinStarredTalks();
-        }
-
-        if (isDownloaded)
-        {
-            query += joinDownloadedTalks();
-        }
-
-        query += joinTalkIdVenueId();
-
-        String where = " WHERE ";
-
-        if (searchTerms != null && !searchTerms.isEmpty())
-        {
-            String[] selectionColumns = new String[]
-            {
-                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.TITLE,
-                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.DESCRIPTION,
-            };
-
-            where += getSearchStatement(searchTerms, selectionColumns) + " AND ";
-        }
-
-        where += String.format(
-                " %s.%s = %s ",
-                DBManager.C.Talk.TABLE_NAME,
-                DBManager.C.Talk.VENUE_ID,
-                venueId
-        );
-
-        query += where + " ORDER BY talks.rec_date DESC ";
-
-        return queryIfNotNull(query, null);
+    ) {
+        return getTalks(talkAdapterColumns, searchTerms, isStarred, isDownloaded,
+                DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.ID + "=" + venueId);
     }
 
 
-    private String joinStarredTalks()
-    {
+    private String joinStarredTalks() {
         return innerJoin(
                 DBManager.C.TalkStars.TABLE_NAME,
                 DBManager.C.TalkStars.TABLE_NAME + "." + DBManager.C.TalkStars.ID,
@@ -246,8 +194,7 @@ public class TalkRepository extends Repository
         );
     }
 
-    private String joinDownloadedTalks()
-    {
+    private String joinDownloadedTalks() {
         return innerJoin(
                 DBManager.C.DownloadedTalks.TABLE_NAME,
                 DBManager.C.DownloadedTalks.TABLE_NAME + "." + DBManager.C.DownloadedTalks.ID,
@@ -255,8 +202,7 @@ public class TalkRepository extends Repository
         );
     }
 
-    private String joinTalkIdTeacherId()
-    {
+    private String joinTalkIdTeacherId() {
         return innerJoin(
                 DBManager.C.Teacher.TABLE_NAME,
                 DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.ID,
@@ -264,8 +210,7 @@ public class TalkRepository extends Repository
         );
     }
 
-    private String joinTalkIdVenueId()
-    {
+    private String joinTalkIdVenueId() {
         return innerJoin(
                 DBManager.C.Center.TABLE_NAME,
                 DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.ID,

--- a/app/src/main/java/org/dharmaseed/android/TeacherCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/TeacherCursorAdapter.java
@@ -52,6 +52,10 @@ public class TeacherCursorAdapter extends StarCursorAdapter {
         TextView title=(TextView)view.findViewById(R.id.item_view_title);
         title.setText(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.NAME)).trim());
 
+        // Get number of talks by this teacher
+        TextView numTalks=(TextView)view.findViewById(R.id.item_view_detail1);
+        numTalks.setText(cursor.getString(cursor.getColumnIndexOrThrow("talk_count")) + " talks");
+
         // Set teacher photo
         String photoFilename = DBManager.getTeacherPhotoFilename(cursor.getInt(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.ID)));
         ImageView photoView = (ImageView) view.findViewById(R.id.item_view_photo);

--- a/app/src/main/java/org/dharmaseed/android/TeacherCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/TeacherCursorAdapter.java
@@ -48,10 +48,9 @@ public class TeacherCursorAdapter extends StarCursorAdapter {
     public void bindView(View view, Context context, Cursor cursor) {
 
         // Set teacher name
+        clearView(view);
         TextView title=(TextView)view.findViewById(R.id.item_view_title);
-        TextView subtitle=(TextView)view.findViewById(R.id.item_view_subtitle);
         title.setText(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.NAME)).trim());
-        subtitle.setText("");
 
         // Set teacher photo
         String photoFilename = DBManager.getTeacherPhotoFilename(cursor.getInt(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.ID)));

--- a/app/src/main/java/org/dharmaseed/android/TeacherRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/TeacherRepository.java
@@ -34,8 +34,12 @@ public class TeacherRepository extends Repository
 
     public Cursor getTeachers(List<String> searchTerms, boolean isStarred)
     {
-        String query = "SELECT teachers._id, teachers.name FROM teachers ";
-        String innerJoin = "";
+        String query = "SELECT teachers._id, teachers.name, count(talks._id) AS talk_count FROM teachers ";
+        String innerJoin = innerJoin(
+                DBManager.C.Talk.TABLE_NAME,
+                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.TEACHER_ID,
+                DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.ID
+        );
 
         if (isStarred)
         {
@@ -60,6 +64,7 @@ public class TeacherRepository extends Repository
 
         query += where;
 
+        query += " GROUP BY teachers._id";
         query += " ORDER BY teachers.monastic DESC, teachers.name ASC";
 
         Log.d(LOG_TAG, query);

--- a/app/src/main/res/layout/main_list_view_item.xml
+++ b/app/src/main/res/layout/main_list_view_item.xml
@@ -54,8 +54,44 @@
             android:layout_height="wrap_content"
             android:text="Teacher"
             android:textAppearance="?android:attr/textAppearanceListItem"
-            android:id="@+id/item_view_subtitle"
+            android:id="@+id/item_view_detail1"
             android:textColor="@color/colorPrimary" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Center"
+            android:textAppearance="?android:attr/textAppearanceListItem"
+            android:id="@+id/item_view_detail2"
+            android:textColor="@color/colorPrimary" />
+
+
+        <RelativeLayout
+            android:orientation="horizontal"
+            android:layout_weight="1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="0dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:text="Date"
+                android:textAppearance="?android:attr/textAppearanceListItem"
+                android:id="@+id/item_view_detail3"
+                android:textColor="@color/colorPrimary" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:text="Duration"
+                android:textAppearance="?android:attr/textAppearanceListItem"
+                android:id="@+id/item_view_detail4"
+                android:textColor="@color/colorPrimary" />
+
+        </RelativeLayout>
 
     </LinearLayout>
 


### PR DESCRIPTION
Specifically, we now include the following in the talk info block (closes #39):
1) Talk title
2) Teacher name
3) Center name
4) Recording date
5) Duration

Also, the number of available talks is now shown in the teachers and centers view (closes #38).  #38 didn't specifically request number of talks to be shown for centers, but it seemed nice to do so for consistency's sake.  @ewoudenberg if you have any thoughts on that, feel free to let us know. :smile: 