### PR TITLE
Include links to website and donation URL in teacher detail view

### DIFF
--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -42,7 +42,7 @@ import java.util.Iterator;
  */
 public class DBManager extends SQLiteOpenHelper {
 
-    private static final int DB_VERSION = 34;
+    private static final int DB_VERSION = 35;
     private static final String DB_NAME = "Dharmaseed.db";
 
     private boolean didUpdate;
@@ -82,6 +82,7 @@ public class DBManager extends SQLiteOpenHelper {
 
         public abstract class Teacher {
             public static final String WEBSITE = "website";
+            public static final String DONATION_URL = "donation_url";
             public static final String BIO = "bio";
             public static final String ID = "_id";
             public static final String NAME = "name";
@@ -93,6 +94,7 @@ public class DBManager extends SQLiteOpenHelper {
             public static final String TABLE_NAME = "teachers";
             public static final String CREATE_TABLE = "CREATE TABLE "+TABLE_NAME+" ("+ID+" INTEGER PRIMARY KEY,"
                     +WEBSITE+" TEXT,"
+                    +DONATION_URL+" TEXT,"
                     +BIO+" TEXT,"
                     +NAME+" TEXT,"
                     +PUBLIC+" INTEGER,"
@@ -277,6 +279,11 @@ public class DBManager extends SQLiteOpenHelper {
             db.execSQL(C.Center.DROP_TABLE);
             db.execSQL(C.Center.CREATE_TABLE);
             clearEdition(db, C.Center.TABLE_NAME);
+
+            // DB version 35 added the "donation_url" column to the teachers table (see #41)
+            db.execSQL(C.Teacher.DROP_TABLE);
+            db.execSQL(C.Teacher.CREATE_TABLE);
+            clearEdition(db, C.Teacher.TABLE_NAME);
         }
     }
 

--- a/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
@@ -30,6 +30,8 @@ import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.widget.CursorAdapter;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.text.Html;
+import android.text.method.LinkMovementMethod;
 import android.view.KeyEvent;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
@@ -169,6 +171,7 @@ public class NavigationActivity extends AppCompatActivity
         header = (LinearLayout)findViewById(R.id.nav_sub_header);
         headerPrimary = (TextView)findViewById(R.id.nav_sub_header_primary);
         headerDescription = (TextView)findViewById(R.id.nav_sub_header_description);
+        headerDescription.setMovementMethod(LinkMovementMethod.getInstance());
 
         // Configure navigation view
         navigationView = (NavigationView) findViewById(R.id.nav_view);
@@ -295,7 +298,15 @@ public class NavigationActivity extends AppCompatActivity
         cursor.close();
 
         headerPrimary.setText(teacher.getName());
-        headerDescription.setText(teacher.getBio());
+
+        String descriptionHtml = teacher.getBio().replace("\n", "\n<p>") + "\n<p>";
+        if (!teacher.getWebsite().isEmpty()) {
+            descriptionHtml += String.format("<a href=%s>Visit teacher's website</a><p>\n", teacher.getWebsite());
+        }
+        if (!teacher.getDonationUrl().isEmpty()) {
+            descriptionHtml += String.format("<a href=%s>Donate to this teacher</a><p>\n", teacher.getDonationUrl());
+        }
+        headerDescription.setText(Html.fromHtml(descriptionHtml));
     }
 
     public void displayTalksByTeacher(long id)

--- a/app/src/main/java/org/dharmaseed/android/Teacher.java
+++ b/app/src/main/java/org/dharmaseed/android/Teacher.java
@@ -7,6 +7,7 @@ public class Teacher
     private int id;
 
     private String website;
+    private String donationUrl;
     private String bio;
     private String name;
     private String photo;
@@ -32,6 +33,7 @@ public class Teacher
         {
             teacher.setId(cursor.getInt(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.ID)));
             teacher.setWebsite(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.WEBSITE)));
+            teacher.setDonationUrl(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.DONATION_URL)));
             teacher.setBio(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.BIO)));
             teacher.setName(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.NAME)));
             teacher.setPhoto(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.PHOTO)));
@@ -56,6 +58,14 @@ public class Teacher
 
     public void setWebsite(String website) {
         this.website = website;
+    }
+
+    public String getDonationUrl() {
+        return donationUrl;
+    }
+
+    public void setDonationUrl(String donationUrl) {
+        this.donationUrl = donationUrl;
     }
 
     public String getBio() {

--- a/app/src/main/java/org/dharmaseed/android/TeacherFetcherTask.java
+++ b/app/src/main/java/org/dharmaseed/android/TeacherFetcherTask.java
@@ -50,6 +50,7 @@ public class TeacherFetcherTask extends DataFetcherTask {
                 "teachers/",
                 new String[]{
                         DBManager.C.Teacher.WEBSITE,
+                        DBManager.C.Teacher.DONATION_URL,
                         DBManager.C.Teacher.BIO,
                         DBManager.C.Teacher.NAME,
                         DBManager.C.Teacher.PHOTO,


### PR DESCRIPTION
Closes #41

This commit includes an update pre-seeded database with the new "donation_url" column

Here's what the updated teacher detail view looks like:

![screenshot_1548011501](https://user-images.githubusercontent.com/10068296/51443869-36232d00-1ca4-11e9-8690-3b49eacb87a0.png)

If a teacher doesn't have a website or donation URL, the links will be omitted from the view.