### PR TITLE
Move website and donation links to be always visible below teacher/center name

### DIFF
--- a/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
@@ -72,7 +72,7 @@ public class NavigationActivity extends AppCompatActivity
     EditText searchBox;
     String extraSearchTerms;
     LinearLayout searchCluster, header;
-    TextView headerPrimary, headerDescription;
+    TextView headerPrimary, headerDescription, websiteLink, donationLink;
     boolean starFilterOn;
     Menu menu;
     DBManager dbManager;
@@ -171,7 +171,10 @@ public class NavigationActivity extends AppCompatActivity
         header = (LinearLayout)findViewById(R.id.nav_sub_header);
         headerPrimary = (TextView)findViewById(R.id.nav_sub_header_primary);
         headerDescription = (TextView)findViewById(R.id.nav_sub_header_description);
-        headerDescription.setMovementMethod(LinkMovementMethod.getInstance());
+        websiteLink = (TextView)findViewById(R.id.nav_links_website);
+        donationLink = (TextView)findViewById(R.id.nav_links_donate);
+        websiteLink.setMovementMethod(LinkMovementMethod.getInstance());
+        donationLink.setMovementMethod(LinkMovementMethod.getInstance());
 
         // Configure navigation view
         navigationView = (NavigationView) findViewById(R.id.nav_view);
@@ -299,14 +302,17 @@ public class NavigationActivity extends AppCompatActivity
 
         headerPrimary.setText(teacher.getName());
 
-        String descriptionHtml = teacher.getBio().replace("\n", "\n<p>") + "\n<p>";
         if (!teacher.getWebsite().isEmpty()) {
-            descriptionHtml += String.format("<a href=%s>Visit teacher's website</a><p>\n", teacher.getWebsite());
+            websiteLink.setText(Html.fromHtml(String.format("<a href=%s>Teacher's website</a>", teacher.getWebsite())));
+        } else {
+            websiteLink.setText("");
         }
         if (!teacher.getDonationUrl().isEmpty()) {
-            descriptionHtml += String.format("<a href=%s>Donate to this teacher</a><p>\n", teacher.getDonationUrl());
+            donationLink.setText(Html.fromHtml(String.format("<a href=%s>Donate to this teacher</a>", teacher.getDonationUrl())));
+        } else {
+            donationLink.setText("");
         }
-        headerDescription.setText(Html.fromHtml(descriptionHtml));
+        headerDescription.setText(teacher.getBio());
     }
 
     public void displayTalksByTeacher(long id)
@@ -334,9 +340,12 @@ public class NavigationActivity extends AppCompatActivity
 
         String descriptionHtml = center.getDescription().replace("\n", "\n<p>") + "\n<p>";
         if (!center.getWebsite().isEmpty()) {
-            descriptionHtml += String.format("<a href=%s>Visit center's website</a><p>\n", center.getWebsite());
+            websiteLink.setText(Html.fromHtml(String.format("<a href=%s>Center's website</a>", center.getWebsite())));
+        } else {
+            websiteLink.setText("");
         }
-        headerDescription.setText(Html.fromHtml(descriptionHtml));
+        donationLink.setText("");
+        headerDescription.setText(center.getDescription());
     }
 
     private void displayTalksByCenter(long id)

--- a/app/src/main/res/layout/content_navigation.xml
+++ b/app/src/main/res/layout/content_navigation.xml
@@ -46,6 +46,39 @@
             android:textStyle="bold"
             />
 
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="25dp"
+                android:id="@+id/nav_links_header"
+                android:orientation="horizontal"
+                android:background="@color/button_material_light">
+
+            <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:layout_gravity="left"
+                    android:gravity="left"
+                    android:text="Visit website"
+                    android:id="@+id/nav_links_website"
+                    android:textColor="@color/colorPrimaryDark"
+                    android:textStyle=""
+            />
+
+            <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:layout_gravity="right"
+                    android:gravity="right"
+                    android:text="Donate to teacher"
+                    android:id="@+id/nav_links_donate"
+                    android:textColor="@color/colorPrimaryDark"
+                    android:textStyle=""
+            />
+
+        </LinearLayout>
+
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="0dp"


### PR DESCRIPTION
Closes #68

Screenshots of how the teacher and center detail pages now look:

![screenshot_1548354968](https://user-images.githubusercontent.com/10068296/51700427-f7eb7d80-1fc3-11e9-93c3-48a8cc71f1b0.png)
![screenshot_1548354970](https://user-images.githubusercontent.com/10068296/51700428-f7eb7d80-1fc3-11e9-89b6-73b87b8771cb.png)
![screenshot_1548354986](https://user-images.githubusercontent.com/10068296/51700429-f8841400-1fc3-11e9-88d2-56a6cb23e4e6.png)
![screenshot_1548354989](https://user-images.githubusercontent.com/10068296/51700431-f8841400-1fc3-11e9-91ae-b7c3aed9a65b.png)

@ewoudenberg, let me know what you think of this new layout.