### PR TITLE
Fix downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /captures
 /app/build
 .idea
+/app/release

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
 
     <!-- Internet Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- For downloading talks -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,8 +21,6 @@
 
     <!-- Internet Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- For downloading talks -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -46,10 +46,11 @@ public class DBManager extends SQLiteOpenHelper {
 
     private static final int DB_VERSION = 1;
     private static final String DB_NAME = "Dharmaseed.db";
+    private static final String LOG_TAG = "DBManager";
 
     private static DBManager instance = null;
-
     private boolean didUpdate;
+    private Context context;
 
     // Database contract class
     final class C {
@@ -189,7 +190,7 @@ public class DBManager extends SQLiteOpenHelper {
 
     private DBManager(Context context) {
         super(context, DB_NAME, null, DB_VERSION);
-
+        this.context = context;
         didUpdate = false;
 
         if (context != null) {
@@ -233,6 +234,8 @@ public class DBManager extends SQLiteOpenHelper {
     protected String getDbName() {
         return DB_NAME;
     }
+
+    public Context getContext() { return context; }
 
     @Override
     public void onConfigure(SQLiteDatabase db) {
@@ -405,23 +408,27 @@ public class DBManager extends SQLiteOpenHelper {
     /**
      * Updates the Talk table to set the "file_path" column to the empty string and removes
      * the talk id from the downloaded_talks table
-     * @param talk the talk to delete
+     * @param talkId the talk ID to delete
      * @return true if all rows were updated successfully, false if at least one was not
      */
-    public boolean removeDownload(Talk talk) {
+    public boolean removeDownload(int talkId) {
         SQLiteDatabase db = getWritableDatabase();
         ContentValues cv = new ContentValues();
         cv.put(C.Talk.FILE_PATH, ""); // a path of "" indicates that the talk is not downloaded
-        String whereClause = C.Talk.ID + "=" + talk.getId();
+        String whereClause = C.Talk.ID + "=" + talkId;
         if (db.update(C.Talk.TABLE_NAME, cv, whereClause, null) != 1)
             return false;
 
         // remove row from downloaded_talks table
-        whereClause = C.DownloadedTalks.ID + "=" + talk.getId();
+        whereClause = C.DownloadedTalks.ID + "=" + talkId;
         if (db.delete(C.DownloadedTalks.TABLE_NAME, whereClause, null) != 1)
             return false;
 
         return true;
+    }
+
+    public boolean removeDownload(Talk talk) {
+        return removeDownload(talk.getId());
     }
 
     /**

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -384,25 +384,30 @@ public class DBManager extends SQLiteOpenHelper {
     /**
      * Updates the Talk table to set the "file_path" column to the talk path
      * also add the Talk ID to the downloaded_talks table
-     * @param talk the talk to add
+     * @param talkId the talk ID
+     * @param talkPath the path to the talk's downloaded file
      * @return true if all rows were updated successfully, false if at least one was not
      */
-    public boolean addDownload(Talk talk) {
+    public boolean addDownload(int talkId, String talkPath) {
         SQLiteDatabase db = getWritableDatabase();
         ContentValues cv = new ContentValues();
-        cv.put(C.Talk.FILE_PATH, talk.getPath());
-        String whereClause = C.Talk.ID + "=" + talk.getId();
+        cv.put(C.Talk.FILE_PATH, talkPath);
+        String whereClause = C.Talk.ID + "=" + talkId;
         if (db.update(C.Talk.TABLE_NAME, cv, whereClause, null) != 1)
             return false;
 
         // add id to downloaded_talks table
         cv.clear();
-        cv.put(C.DownloadedTalks.ID, talk.getId());
+        cv.put(C.DownloadedTalks.ID, talkId);
         // insert returns a -1 on error
         if (db.insert(C.DownloadedTalks.TABLE_NAME, null, cv) == -1)
             return false;
 
         return true;
+    }
+
+    public boolean addDownload(Talk talk) {
+        return addDownload(talk.getId(), talk.getPath());
     }
 
     /**

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -96,7 +96,7 @@ public class PlayTalkActivity extends AppCompatActivity
             Cursor cursor = getCursor();
             if (cursor.moveToFirst()) {
                 // convert DB result to an object
-                talk = new Talk(cursor);
+                talk = new Talk(cursor, getApplicationContext());
                 talk.setId(talkID);
             } else {
                 Log.e(LOG_TAG, "Could not look up talk, id="+talkID);
@@ -305,6 +305,7 @@ public class PlayTalkActivity extends AppCompatActivity
             setPPButton("ic_media_pause");
         } else {
             try {
+                mediaPlayer.reset();
                 if (talk.isDownloaded()) {
                     Log.d(LOG_TAG, "Playing from " + talk.getPath());
                     mediaPlayer.setDataSource(talk.getPath());
@@ -312,7 +313,8 @@ public class PlayTalkActivity extends AppCompatActivity
                     mediaPlayer.setDataSource(talk.getAudioUrl());
                 }
                 mediaPlayer.prepareAsync();
-            } catch (Exception e) {
+            } catch (java.io.IOException e) {
+                e.printStackTrace();
                 Log.e(LOG_TAG, e.toString());
             }
         }
@@ -362,36 +364,7 @@ public class PlayTalkActivity extends AppCompatActivity
      * Download the talk if we have permission. If we don't have permission, request it
      */
     private void downloadTalk() {
-        int permission = ContextCompat.checkSelfPermission(
-                this, Manifest.permission.WRITE_EXTERNAL_STORAGE
-        );
-        if (permission != PackageManager.PERMISSION_GRANTED) {
-            // requestPermissions will ask the user for permission asynchronously
-            // and will call onRequestPermissionsResult() with the results
-            ActivityCompat.requestPermissions(
-                    this,
-                    new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                    PERMISSIONS_WRITE_EXTERNAL_STORAGE
-            );
-        } else if (permission == PackageManager.PERMISSION_GRANTED) {
-            new DownloadTalkTask().execute(talk);
-        } else {
-            // should never happen
-            Log.w(LOG_TAG, "Permission was " + permission);
-        }
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] results) {
-        switch (requestCode) {
-            case PERMISSIONS_WRITE_EXTERNAL_STORAGE:
-                // we asked for and received permission
-                if (results.length > 0 && results[0] == PackageManager.PERMISSION_GRANTED) {
-                    new DownloadTalkTask().execute(talk);
-                }
-                // if we didn't receive permission, don't do anything
-                return;
-        }
+        new DownloadTalkTask().execute(talk);
     }
 
     public void toggleDownloadImage() {
@@ -538,4 +511,3 @@ public class PlayTalkActivity extends AppCompatActivity
         }
     }
 }
-

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -308,7 +308,7 @@ public class PlayTalkActivity extends AppCompatActivity
                 mediaPlayer.reset();
                 if (talk.isDownloaded()) {
                     Log.d(LOG_TAG, "Playing from " + talk.getPath());
-                    mediaPlayer.setDataSource(talk.getPath());
+                    mediaPlayer.setDataSource("file://" + talk.getPath());
                 } else {
                     mediaPlayer.setDataSource(talk.getAudioUrl());
                 }

--- a/app/src/main/java/org/dharmaseed/android/Repository.java
+++ b/app/src/main/java/org/dharmaseed/android/Repository.java
@@ -11,9 +11,9 @@ import java.util.List;
 public abstract class Repository
 {
 
-    protected SQLiteOpenHelper dbManager;
+    protected DBManager dbManager;
 
-    public Repository(SQLiteOpenHelper dbManager)
+    public Repository(DBManager dbManager)
     {
         this.dbManager = dbManager;
     }

--- a/app/src/main/java/org/dharmaseed/android/Talk.java
+++ b/app/src/main/java/org/dharmaseed/android/Talk.java
@@ -12,7 +12,6 @@ public class Talk {
     private String title;
     private String description;
     private String audioUrl;
-    private String downloadUrl; // this is different from the audio url
     private String date;
     private String teacherName;
     private String centerName;
@@ -41,14 +40,6 @@ public class Talk {
 
         String url = cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Talk.AUDIO_URL));
         setAudioUrl("http://www.dharmaseed.org" + url);
-
-        String[] data = url.split("/");
-        String downloadPrefix = "https://media.dharmaseed.org/cache/DS/";
-
-        if (data.length > 0) {
-            // we want the path after the last '/'
-            setDownloadUrl(downloadPrefix + data[data.length - 1]);
-        }
 
         String recDate = cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Talk.RECORDING_DATE));
         if(recDate == null) {
@@ -81,10 +72,6 @@ public class Talk {
 
     public String getAudioUrl() {
         return audioUrl;
-    }
-
-    public String getDownloadUrl() {
-        return downloadUrl;
     }
 
     public double getDurationInMinutes() {
@@ -145,10 +132,6 @@ public class Talk {
 
     private void setAudioUrl(String audioUrl) {
         this.audioUrl = audioUrl;
-    }
-
-    private void setDownloadUrl(String downloadUrl) {
-        this.downloadUrl = downloadUrl;
     }
 
     private void setDurationInMinutes(double durationInMinutes) {

--- a/app/src/main/java/org/dharmaseed/android/Talk.java
+++ b/app/src/main/java/org/dharmaseed/android/Talk.java
@@ -1,6 +1,9 @@
 package org.dharmaseed.android;
 
+import android.content.Context;
 import android.database.Cursor;
+
+import java.io.File;
 
 /**
  * Model of the TALK table in the DB
@@ -23,10 +26,13 @@ public class Talk {
     private int teacherId;
     private int retreatId;
 
+    private Context context;
+
     private double durationInMinutes;
 
-    public Talk(Cursor cursor) {
+    public Talk(Cursor cursor, Context context) {
         this.create(cursor);
+        this.context = context;
     }
 
     /**
@@ -60,6 +66,7 @@ public class Talk {
         setDurationInMinutes(cursor.getDouble(cursor.getColumnIndexOrThrow(DBManager.C.Talk.DURATION_IN_MINUTES)));
 
         setPath(cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Talk.FILE_PATH)));
+
     }
 
     public String getTitle() {
@@ -108,6 +115,10 @@ public class Talk {
 
     public int getRetreatId() {
         return retreatId;
+    }
+
+    public Context getContext() {
+        return context;
     }
 
     /**

--- a/app/src/main/java/org/dharmaseed/android/TalkManager.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkManager.java
@@ -44,12 +44,20 @@ public abstract class TalkManager {
         long size = 0;
 
         try {
-            URL talkUrl = new URL(talk.getDownloadUrl());
+            URL talkUrl = new URL(talk.getAudioUrl());
             HttpURLConnection connection = (HttpURLConnection) talkUrl.openConnection();
 
             int response = connection.getResponseCode();
+            while (response != HttpURLConnection.HTTP_OK &&
+                    (response == HttpURLConnection.HTTP_MOVED_PERM || response == HttpURLConnection.HTTP_MOVED_TEMP)) {
+                talkUrl = new URL(connection.getHeaderField("Location"));
+                connection = (HttpURLConnection) talkUrl.openConnection();
+                Log.i(LOG_TAG, "Following redirect to " + talkUrl);
+                response = connection.getResponseCode();
+            }
+
             if (response != HttpURLConnection.HTTP_OK) {
-                Log.e(LOG_TAG, "Talk " + talk.getId() + " URL returned " + response);
+                Log.e(LOG_TAG, "Talk URL " + connection.getURL() + " returned " + response);
                 return FAILURE;
             }
 

--- a/app/src/main/java/org/dharmaseed/android/TalkManager.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkManager.java
@@ -1,5 +1,6 @@
 package org.dharmaseed.android;
 
+import android.content.Context;
 import android.os.Environment;
 import android.util.Log;
 
@@ -18,7 +19,7 @@ import java.net.URL;
 public abstract class TalkManager {
 
     // folder where talks are stored on the device
-    public static final String DIR_NAME = "dharmaseed";
+    public static final String DIR_NAME = "downloads";
     public static final String FILE_PREFIX = "ds_";
 
     private static final String LOG_TAG = "TalkManager";
@@ -36,7 +37,7 @@ public abstract class TalkManager {
         if (!isExternalStorageWritable())
             return FAILURE;
 
-        File dir = getDir();
+        File dir = getDir(talk.getContext());
         if (dir == null)
             return FAILURE;
 
@@ -45,6 +46,7 @@ public abstract class TalkManager {
 
         try {
             URL talkUrl = new URL(talk.getAudioUrl());
+            Log.i(LOG_TAG, "Downloading " + talkUrl);
             HttpURLConnection connection = (HttpURLConnection) talkUrl.openConnection();
 
             int response = connection.getResponseCode();
@@ -79,6 +81,8 @@ public abstract class TalkManager {
             inputStream.close();
 
             talk.setPath(talkPath);
+            Log.i(LOG_TAG, "Downloaded talk to " + talkPath);
+
             return size;
         } catch (MalformedURLException murlex) {
             Log.e(LOG_TAG, murlex.getMessage());
@@ -94,9 +98,9 @@ public abstract class TalkManager {
     /**
      * @return the directory where we store talks
      */
-    public static File getDir() {
+    public static File getDir(Context context) {
         File file = new File(
-                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MUSIC),
+                context.getFilesDir(),
                 DIR_NAME
         );
 
@@ -134,8 +138,7 @@ public abstract class TalkManager {
         if (file.exists())
             result = file.delete();
 
-        if (result)
-            talk.setPath("");
+         talk.setPath("");
 
         // if the file somehow didn't exist then we'll just say it was deleted anyway
         return result;

--- a/app/src/main/java/org/dharmaseed/android/TalkRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkRepository.java
@@ -1,11 +1,15 @@
 package org.dharmaseed.android;
 
 import android.database.Cursor;
-import android.database.sqlite.SQLiteOpenHelper;
 import android.text.TextUtils;
 import android.util.Log;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -187,7 +191,8 @@ public class TalkRepository extends Repository {
                 DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.ID + "=" + venueId);
     }
 
-    /** Check if we have talks downloaded in old/inaccessible locations, and mark them as not downloaded if so
+    /**
+     * Check if we have talks downloaded in old/inaccessible locations, and mark them as not downloaded if so
      *
      */
     public void removeOldDownloads()
@@ -205,16 +210,52 @@ public class TalkRepository extends Repository {
         {
             int id = downloaded.getInt(downloaded.getColumnIndexOrThrow(DBManager.getAlias(
                     DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.ID)));
-            String path = downloaded.getString(downloaded.getColumnIndexOrThrow(DBManager.getAlias(
-                    DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.FILE_PATH))).trim();
+            File file = new File(downloaded.getString(downloaded.getColumnIndexOrThrow(DBManager.getAlias(
+                    DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.FILE_PATH))).trim());
 
-            String fullPath = new File(path).getAbsolutePath();
-            String downloadPath = TalkManager.getDir(dbManager.getContext()).getAbsolutePath();
+            String directory = file.getAbsoluteFile().getParent();
+            String downloadDirectory = TalkManager.getDir(dbManager.getContext()).getAbsolutePath();
 
-            if (! fullPath.startsWith(downloadPath)) {
-                Log.w(LOG_TAG, "Removing old download for talk " + id);
+            if (! directory.equals(downloadDirectory)) {
+                Log.w(LOG_TAG, "Detected old style download for talk " + file.toString());
                 dbManager.removeDownload(id);
+
+                try {
+                    File copyTarget = new File(downloadsDir.toString() + "/" + file.getName());
+                    copy(file, copyTarget);
+                    dbManager.addDownload(id, copyTarget.toString());
+                    Log.i(LOG_TAG, "Successfully moved old talk to " + copyTarget.toString());
+                    file.delete();
+                } catch (IOException e) {
+                    Log.e(LOG_TAG, e.toString());
+                }
             }
+        }
+    }
+
+    /**
+     * Copy src to dst.  From https://stackoverflow.com/questions/9292954/how-to-make-a-copy-of-a-file-in-android
+     * Unfortunately, Files.copy is not available before API version 26
+     * @param src
+     * @param dst
+     * @throws IOException
+     */
+    private static void copy(File src, File dst) throws IOException {
+        InputStream in = new FileInputStream(src);
+        try {
+            OutputStream out = new FileOutputStream(dst);
+            try {
+                // Transfer bytes from in to out
+                byte[] buf = new byte[1024];
+                int len;
+                while ((len = in.read(buf)) > 0) {
+                    out.write(buf, 0, len);
+                }
+            } finally {
+                out.close();
+            }
+        } finally {
+            in.close();
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 19 16:05:15 PST 2019
+#Sun Oct 06 12:23:15 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
It seems that downloads have been broken for a little while (I've received a couple of emails about it recently).  Investigating, it seems that the media URL we were previously using has changed a bit.  This PR follows redirects from the actual audio URL we get from dharmaseed, which should hopefully be a more reliable way to download talks.