### PR TITLE
Persistent Talk progress

### DIFF
--- a/app/src/main/java/org/dharmaseed/android/AbstractDBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/AbstractDBManager.java
@@ -162,6 +162,19 @@ public abstract class AbstractDBManager extends SQLiteOpenHelper {
             public static final String DROP_TABLE = "DROP TABLE IF EXISTS " + TABLE_NAME;
         }
 
+        public abstract class TalkHistory {
+            public static final String ID = "_id";
+            public static final String PROGRESS_IN_MINUTES = "progress_in_minutes";
+            public static final String DATE_TIME = "date_time";
+            public static final String TABLE_NAME = "talk_history";
+            public static final String CREATE_TABLE = "CREATE TABLE " + TABLE_NAME + " (" + ID + " INTEGER PRIMARY KEY,"
+                    + DATE_TIME + " TEXT,"
+                    + PROGRESS_IN_MINUTES + " REAL"
+                    + ")";
+            public static final String DROP_TABLE = "DROP TABLE IF EXISTS " + TABLE_NAME;
+        }
+
+
         public abstract class TeacherStars {
             public static final String ID = "_id";
 

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -23,6 +23,8 @@ import android.app.DialogFragment;
 import android.graphics.drawable.Animatable;
 import android.os.AsyncTask;
 import android.os.Handler;
+
+import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.FragmentManager;
 import android.content.Intent;
@@ -74,8 +76,11 @@ public class PlayTalkActivity extends AppCompatActivity
     // request code for writing external storage (the number is arbitrary)
     private static final int PERMISSIONS_WRITE_EXTERNAL_STORAGE = 9087;
 
-    protected void prepareTalkPlayerFragment(TalkPlayerFragment talkPlayerFragment)
+    protected void prepareTalkPlayerFragment()
     {
+        if (talkPlayerFragment == null)
+            Log.e(LOG_TAG, "talkPlayerFragment must be non-null!");
+
         final MediaPlayer mediaPlayer = talkPlayerFragment.getMediaPlayer();
         try {
             mediaPlayer.reset();
@@ -89,7 +94,8 @@ public class PlayTalkActivity extends AppCompatActivity
             e.printStackTrace();
             Log.e(LOG_TAG, e.toString());
         }
-        Log.i(LOG_TAG,"created player fragment for "+talkID);
+        Log.i(LOG_TAG,"preparing media player for "+talkID);
+        mediaPlayer.prepareAsync();
     }
 
     @Override
@@ -183,7 +189,6 @@ public class PlayTalkActivity extends AppCompatActivity
             // add the fragment
             talkPlayerFragment = new TalkPlayerFragment();
             fm.beginTransaction().add(talkPlayerFragment, "talkPlayerFragment").commit();
-            prepareTalkPlayerFragment(talkPlayerFragment);
 
             // retrieve progress from TalkHistory DB table
             final int pos = (int) (dbManager.getTalkProgress(talkID)*60*1000);
@@ -419,11 +424,10 @@ public class PlayTalkActivity extends AppCompatActivity
             mediaPlayer.start();
             setPPButton("ic_media_pause");
         } else {
-            Log.i(LOG_TAG, "preparing media player for talk "+talkID);
             ImageButton playButton = (ImageButton) findViewById(R.id.activity_play_talk_play_button);
             playButton.setAlpha(.5f);
             playButton.setClickable(false);
-            mediaPlayer.prepareAsync();
+            prepareTalkPlayerFragment();
         }
     }
 

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -199,6 +199,8 @@ public class PlayTalkActivity extends AppCompatActivity
         seekBar.setMax((int)(duration*60*1000));
         userDraggingSeekBar = false;
         seekBar.setOnSeekBarChangeListener(this);
+        final int pos = (int) (dbManager.getTalkProgress(talkID)*60*1000);
+        seekBar.setProgress(pos);
 
         // Get/create a persistent fragment to manage the MediaPlayer instance
         FragmentManager fm = getSupportFragmentManager();
@@ -279,6 +281,7 @@ public class PlayTalkActivity extends AppCompatActivity
             SimpleDateFormat parser = new SimpleDateFormat(DATE_FORMAT);
             final String now = parser.format(GregorianCalendar.getInstance().getTime());
             Log.d(LOG_TAG, "talk "+talkID+": progress POS="+pos+" on DATE="+now);
+            dbManager.setTalkProgress(talkID, now, pos/(1000*60.0));
         }
     }
 

--- a/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
@@ -29,6 +29,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.ProgressBar;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -94,8 +95,23 @@ public class TalkCursorAdapter extends StarCursorAdapter {
             photoView.setImageDrawable(icon);
         }
 
+        // get talk ID from cursor
+        final int talkID = cursor.getInt(cursor.getColumnIndexOrThrow(DBManager.C.Talk.ID));
+
+        // Show talk progress
+        ProgressBar talk_progress = (ProgressBar) view.findViewById(R.id.item_view_progress);
+        int duration_s = (int) (60*duration);
+        int progress_s = (int) (60*dbManager.getTalkProgress(talkID));
+        if (progress_s > 0) {
+            talk_progress.setMax(duration_s);
+            talk_progress.setProgress(progress_s);
+            talk_progress.setVisibility(View.VISIBLE);
+        } else {
+            talk_progress.setVisibility(View.GONE);
+        }
+
         // Set talk stars
-        handleStars(view, cursor.getInt(cursor.getColumnIndexOrThrow(DBManager.C.Talk.ID)));
+        handleStars(view, talkID);
     }
 
 

--- a/app/src/main/java/org/dharmaseed/android/TalkPlayerFragment.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkPlayerFragment.java
@@ -70,11 +70,10 @@ public class TalkPlayerFragment extends Fragment
     public void onPrepared(MediaPlayer mp) {
         Log.i("talkPlayerFragment", "media prepared");
         mediaPrepared = true;
-        //mediaPlayer.start();
         PlayTalkActivity activity = (PlayTalkActivity) getActivity();
-        activity.setPPButton("ic_media_play");
-        activity.setButtonsEnabled(true);
-        mediaPlayer.seekTo(activity.getSeekBarProgress());
+        activity.setTalkProgress(activity.getSeekBarProgress(), false);
+        mediaPlayer.start();
+        activity.setPPButton("ic_media_pause");
     }
 
     @Override

--- a/app/src/main/java/org/dharmaseed/android/TalkPlayerFragment.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkPlayerFragment.java
@@ -24,6 +24,7 @@ import android.media.MediaPlayer;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import android.util.Log;
+import android.widget.ImageButton;
 
 /**
  * Created by bbethke on 3/12/16.
@@ -36,19 +37,17 @@ public class TalkPlayerFragment extends Fragment
 
     private MediaPlayer mediaPlayer;
     private boolean mediaPrepared;
-    private int userSeekBarPosition;
 
     public TalkPlayerFragment() {
         mediaPlayer = new MediaPlayer();
         mediaPlayer.setAudioAttributes(
                 new AudioAttributes.Builder()
-                    .setUsage(AudioAttributes.USAGE_MEDIA)
-                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-                    .build()
+                        .setUsage(AudioAttributes.USAGE_MEDIA)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .build()
         );
         mediaPlayer.setOnPreparedListener(this);
         mediaPrepared = false;
-        userSeekBarPosition = 0;
     }
 
     // this method is only called once for this fragment
@@ -67,18 +66,15 @@ public class TalkPlayerFragment extends Fragment
         return mediaPrepared;
     }
 
-    public void setUserSeekBarPosition(int userSeekBarPosition) {
-        this.userSeekBarPosition = userSeekBarPosition;
-    }
-
     @Override
     public void onPrepared(MediaPlayer mp) {
-        Log.i("talkPlayerFragment", "playing talk");
+        Log.i("talkPlayerFragment", "media prepared");
         mediaPrepared = true;
-        mediaPlayer.seekTo(userSeekBarPosition);
-        mediaPlayer.start();
+        //mediaPlayer.start();
         PlayTalkActivity activity = (PlayTalkActivity) getActivity();
-        activity.setPPButton("ic_media_pause");
+        activity.setPPButton("ic_media_play");
+        activity.setButtonsEnabled(true);
+        mediaPlayer.seekTo(activity.getSeekBarProgress());
     }
 
     @Override

--- a/app/src/main/res/layout/main_list_view_item.xml
+++ b/app/src/main/res/layout/main_list_view_item.xml
@@ -25,18 +25,18 @@
     android:minHeight="95dp">
 
     <ImageView
-        android:layout_width="60dp"
-        android:layout_height="90dp"
-        android:paddingTop="5dp"
         android:id="@+id/item_view_photo"
+        android:layout_width="60dp"
+        android:layout_height="match_parent"
         android:adjustViewBounds="true"
+        android:paddingTop="5dp"
         android:scaleType="fitStart" />
 
     <LinearLayout
-        android:orientation="vertical"
-        android:layout_weight="1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical"
         android:paddingLeft="5dp">
 
         <TextView
@@ -46,52 +46,58 @@
             android:layout_gravity="left"
             android:text="Talk Title"
             android:textAppearance="?android:attr/textAppearanceListItem"
-            android:textStyle="bold"
-            android:textColor="@color/colorPrimaryDark" />
+            android:textColor="@color/colorPrimaryDark"
+            android:textStyle="bold" />
 
         <TextView
+            android:id="@+id/item_view_detail1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Teacher"
             android:textAppearance="?android:attr/textAppearanceListItem"
-            android:id="@+id/item_view_detail1"
             android:textColor="@color/colorPrimary" />
 
         <TextView
+            android:id="@+id/item_view_detail2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Center"
             android:textAppearance="?android:attr/textAppearanceListItem"
-            android:id="@+id/item_view_detail2"
             android:textColor="@color/colorPrimary" />
 
 
         <RelativeLayout
-            android:orientation="horizontal"
-            android:layout_weight="1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="horizontal"
             android:paddingLeft="0dp">
 
             <TextView
+                android:id="@+id/item_view_detail3"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
                 android:text="Date"
                 android:textAppearance="?android:attr/textAppearanceListItem"
-                android:id="@+id/item_view_detail3"
                 android:textColor="@color/colorPrimary" />
 
             <TextView
+                android:id="@+id/item_view_detail4"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentRight="true"
                 android:text="Duration"
                 android:textAppearance="?android:attr/textAppearanceListItem"
-                android:id="@+id/item_view_detail4"
                 android:textColor="@color/colorPrimary" />
 
         </RelativeLayout>
+
+        <ProgressBar
+            android:id="@+id/item_view_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
     </LinearLayout>
 


### PR DESCRIPTION
Hi there,

I really love dharmaseed and I also love the android app that you have created as an interface to all of those wonderful talks. Thank you!

The one thing that has bothered me now and again is that the app does not keep track of progress when I listen to a talk.... In this busy life of mine I sometimes can't finish a talk in one go and later on I don't remember where I left off (or, in extreme cases, which talk I was listening to!).

The talk_progress branch implements a few changes that make the app remember where I left off. Here is a high-level summary of the new features:

- the DB includes a new "TalkHistory" Table, which keeps track of the current progress of each talk played, as well as  when the progress information was last updated
- the PlayTalkActivity resumes the talk at the last saved position based on the TalkHistory DB
- the ListView item for each talk includes a horizontal progress bar showing the current progress (only for talks that have been started, other talks look exactly as they used to; see the screenshot below, in which two talks by Ajahn Sucitto have progress information associated with them)

The update date/time, which is stored alongside the current progress in the new TalkHistory table, is not currently used. I included it as a basis for implementing a "TalkHistory" feature at some later time (e.g. a ListView that shows the talks played in chronological order). 

I've also cleaned up the internals of the PlayTalkActivity:
- the prepareAsync method of the media player is called immediately, not when the play button is pressed. This made setting the "persisten progress" easier and also addressed a very minor bug whereby the FFWD and REV buttons did not work before the play button was pressed for the first time.
- the onCreate no longer uses a Handler object to update the SeekBar position. The problem with that approach was that the Handler could not be stopped; it kept running even after the activity was stopped and destroyed. The new approach uses a Timer object that is stopped in onDestroy.
 
The new features were tested on the Pixel emulator in Android Studio and I've also got the updated app running on my phone. Everything seems to be working as far as I can tell. The existing instrumentation tests also run fine, however I haven't actually implemented any additional tests for the new features.

As Ajahn Sumedho would probably say: "I submit this fork for your consideration" ;)

All the best,

Marc
 
![dharmaseed_persistent_progress_screenshot](https://github.com/dharmaseed/dharmaseed-android/assets/144038206/c5960c87-ccff-4f1a-b32c-e6e6d48253df)
