### PR TITLE
Set the progress bar visibility to gone by default

### DIFF
--- a/app/src/main/res/layout/main_list_view_item.xml
+++ b/app/src/main/res/layout/main_list_view_item.xml
@@ -96,6 +96,7 @@
         <ProgressBar
             android:id="@+id/item_view_progress"
             style="?android:attr/progressBarStyleHorizontal"
+            android:visibility="gone"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 


### PR DESCRIPTION
Hey @intermarc, I noticed a small issue today: the new progress bar is also showing up by default when viewing teachers and centers. This is a quick PR to set the visibility of the bar to `gone` by default, which will prevent this behavior. The bar will still show up as intended when viewing talks, since the visibility is explicitly set in `TalkCursorAdapter.bindView`.

Sorry I missed this in my earlier review! :stuck_out_tongue: 

I've also invited you to the dharmaseed organization, which I think should allow you to review and approve PRs. I'm still learning about github organizations though, so if you run into any permissions problems, please let me know!

![image](https://github.com/dharmaseed/dharmaseed-android/assets/10068296/56d7cdc6-1f86-4019-bb58-e2eca85601b9)