### PR TITLE
Fixes for crashes seen in production

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "org.dharmaseed.android"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 20
-        versionName "1.5.0"
+        versionCode 21
+        versionName "1.5.1"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ android {
         applicationId "org.dharmaseed.android"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 21
+        versionCode 22
         versionName "1.5.1"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,6 +54,12 @@
                 android:value="org.dharmaseed.android.NavigationActivity" />
         </activity>
 
+        <!-- Use media instead of media3 here to test the theory that some
+             bugs we've seen in production on Samsung devices may have something to do
+             with a buggy media3 implementation on those devices. This is really not much
+             more than a wild guess, though, so eventually we may want to go back to
+             using media3.
+         -->
         <receiver android:name="androidx.media.session.MediaButtonReceiver"
             android:exported="true" >
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,7 +54,7 @@
                 android:value="org.dharmaseed.android.NavigationActivity" />
         </activity>
 
-        <receiver android:name="androidx.media3.session.MediaButtonReceiver"
+        <receiver android:name="androidx.media.session.MediaButtonReceiver"
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -230,7 +230,9 @@ public class DBManager extends AbstractDBManager {
                 starTableName,
                 id);
         Cursor cursor = db.rawQuery(query, null);
-        return (cursor.getCount() != 0);
+        boolean starred = (cursor.getCount() != 0);
+        cursor.close();
+        return starred;
     }
 
     public void addStar(String starTableName, int id) {
@@ -254,10 +256,14 @@ public class DBManager extends AbstractDBManager {
                 C.TalkHistory.ID,
                 id);
         Cursor cursor = db.rawQuery(query, null);
-        if (cursor.getCount() <= 0)
+        if (cursor.getCount() <= 0) {
+            cursor.close();
             return 0.0;
+        }
         cursor.moveToFirst();
-        return cursor.getDouble(0);
+        double progress = cursor.getDouble(0);
+        cursor.close();
+        return progress;
     }
 
     public void setTalkProgress(int id, String date_time, double progress) {
@@ -270,7 +276,8 @@ public class DBManager extends AbstractDBManager {
         v.put(C.TalkHistory.ID, id);
         v.put(C.TalkHistory.DATE_TIME, date_time);
         v.put(C.TalkHistory.PROGRESS_IN_MINUTES, progress);
-        if (db.rawQuery(query, null).getCount() <= 0) {
+        Cursor cursor = db.rawQuery(query, null);
+        if (cursor.getCount() <= 0) {
             db.insert(C.TalkHistory.TABLE_NAME, null, v);
             Log.i(LOG_TAG, "Created new talk history item for talk "+id+"("+progress+" min)");
         } else {
@@ -278,6 +285,7 @@ public class DBManager extends AbstractDBManager {
                     new String[]{Integer.toString(id)});
             Log.i(LOG_TAG, "Updated talk history item for talk "+id+"("+progress+" min)");
         }
+        cursor.close();
         db.close();
     }
 

--- a/app/src/main/java/org/dharmaseed/android/MiniPlayerFragment.java
+++ b/app/src/main/java/org/dharmaseed/android/MiniPlayerFragment.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.ByteArrayInputStream;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -54,7 +55,7 @@ public class MiniPlayerFragment extends Fragment {
                 playerListener.onMediaMetadataChanged(mediaController.getMediaMetadata());
                 playerListener.onPlaybackStateChanged(mediaController.getPlaybackState());
                 playerListener.onIsPlayingChanged(mediaController.isPlaying());
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException | ExecutionException | CancellationException e) {
                 Log.e(LOG_TAG, "Could not create media controller. " + e.toString());
             }
         }, ContextCompat.getMainExecutor(ctx));

--- a/app/src/main/java/org/dharmaseed/android/MiniPlayerFragment.java
+++ b/app/src/main/java/org/dharmaseed/android/MiniPlayerFragment.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ExecutionException;
  */
 public class MiniPlayerFragment extends Fragment {
 
+    private ListenableFuture<MediaController> controllerFuture;
     private MediaController mediaController;
 
     private String LOG_TAG = "MiniPlayerFragment";
@@ -45,9 +46,7 @@ public class MiniPlayerFragment extends Fragment {
         Context ctx = getContext();
         SessionToken sessionToken =
                 new SessionToken(ctx, new ComponentName(ctx, PlaybackService.class));
-        ListenableFuture<MediaController> controllerFuture =
-                new MediaController.Builder(ctx, sessionToken).buildAsync();
-
+        controllerFuture = new MediaController.Builder(ctx, sessionToken).buildAsync();
         controllerFuture.addListener(() -> {
             try {
                 mediaController = controllerFuture.get();
@@ -65,10 +64,7 @@ public class MiniPlayerFragment extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
-        Log.i(LOG_TAG, "onPause " + this);
-        mediaController.removeListener(playerListener);
-        mediaController.release();
-        mediaController = null;
+        MediaController.releaseFuture(controllerFuture);
     }
 
     @Override

--- a/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
@@ -30,6 +30,8 @@ import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.cursoradapter.widget.CursorAdapter;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+import android.os.StrictMode;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.view.KeyEvent;
@@ -154,6 +156,18 @@ public class NavigationActivity extends AppCompatActivity
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+
+        // Uncomment to get StrictMode warnings in the logs
+//        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+//            StrictMode.VmPolicy policy = null;
+//            policy = new StrictMode.VmPolicy.Builder()
+//                    .detectAll()
+//                    .penaltyLog()
+//                    .build();
+//            StrictMode.setVmPolicy(policy);
+//        }
+
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_navigation);
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -57,6 +57,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -151,7 +152,8 @@ public class PlayTalkActivity extends AppCompatActivity
         try {
             FileInputStream photo = openFileInput(photoFilename);
             photoView.setImageBitmap(BitmapFactory.decodeStream(photo));
-        } catch (FileNotFoundException e) {
+            photo.close();
+        } catch (IOException e) {
             Drawable icon = ContextCompat.getDrawable(this, R.drawable.dharmaseed_icon);
             photoView.setImageDrawable(icon);
         }

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -75,6 +75,7 @@ public class PlayTalkActivity extends AppCompatActivity
 
     Timer timer;
 
+    ListenableFuture<MediaController> controllerFuture;
     MediaController mediaController;
 
     Talk talk;
@@ -206,9 +207,7 @@ public class PlayTalkActivity extends AppCompatActivity
         // Create a MediaController to interact with the PlaybackService
         SessionToken sessionToken =
                 new SessionToken(this, new ComponentName(this, PlaybackService.class));
-        ListenableFuture<MediaController> controllerFuture =
-                new MediaController.Builder(this, sessionToken).buildAsync();
-
+        controllerFuture = new MediaController.Builder(this, sessionToken).buildAsync();
         controllerFuture.addListener(() -> {
                 try {
                     mediaController = controllerFuture.get();
@@ -280,9 +279,9 @@ public class PlayTalkActivity extends AppCompatActivity
         }
     }
 
-    public void onStop() {
-        super.onStop();
-        mediaController.release();
+    public void onPause() {
+        super.onPause();
+        MediaController.releaseFuture(controllerFuture);
         Log.i(LOG_TAG, "stopping timers");
         timer.cancel();
     }

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -61,6 +61,7 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.Timer;
 
@@ -216,7 +217,7 @@ public class PlayTalkActivity extends AppCompatActivity
                     mediaController.addListener(playerListener);
                     playerListener.onIsPlayingChanged(mediaController.isPlaying());
                     updatePlayerUI();
-                } catch (InterruptedException | ExecutionException e) {
+                } catch (InterruptedException | ExecutionException | CancellationException e) {
                     Log.e(LOG_TAG, "Could not create media controller. " + e.toString());
                 }
             }, ContextCompat.getMainExecutor(this));

--- a/app/src/main/java/org/dharmaseed/android/PlaybackService.java
+++ b/app/src/main/java/org/dharmaseed/android/PlaybackService.java
@@ -38,6 +38,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -192,7 +193,8 @@ public class PlaybackService extends MediaSessionService {
                 try {
                     FileInputStream photoStream = openFileInput(photoFilename);
                     photo = BitmapFactory.decodeStream(photoStream);
-                } catch (FileNotFoundException e) {
+                    photoStream.close();
+                } catch (IOException e) {
                     photo = BitmapFactory.decodeResource(getResources(), R.drawable.dharmaseed_icon);
                 }
                 ByteArrayOutputStream stream = new ByteArrayOutputStream();

--- a/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
@@ -33,6 +33,7 @@ import android.widget.ProgressBar;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -90,7 +91,8 @@ public class TalkCursorAdapter extends StarCursorAdapter {
         try {
             FileInputStream photo = context.openFileInput(photoFilename);
             photoView.setImageBitmap(BitmapFactory.decodeStream(photo));
-        } catch(FileNotFoundException e) {
+            photo.close();
+        } catch(IOException e) {
             Drawable icon = ContextCompat.getDrawable(context, R.drawable.dharmaseed_icon);
             photoView.setImageDrawable(icon);
         }

--- a/app/src/main/java/org/dharmaseed/android/TalkRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkRepository.java
@@ -231,6 +231,8 @@ public class TalkRepository extends Repository {
                 }
             }
         }
+
+        downloaded.close();
     }
 
     /**


### PR DESCRIPTION
I've been monitoring the stability of #87 in the google play console since we released it to production a few days ago. There have been a couple of crashes that didn't show up in testing and I haven't been able to reproduce. This little PR should fix them, I hope.

# Null pointer exception

This one is fairly straightforward, I think. We're seeing the following crash:

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performPauseActivityIfNeeded (ActivityThread.java:5717)
  at android.app.ActivityThread.performPauseActivity (ActivityThread.java:5668)
  at android.app.ActivityThread.handlePauseActivity (ActivityThread.java:5620)
  at android.app.servertransaction.PauseActivityItem.execute (PauseActivityItem.java:47)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:45)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:176)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2574)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8762)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:604)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
Caused by java.lang.NullPointerException:
  at org.dharmaseed.android.MiniPlayerFragment.onPause (MiniPlayerFragment.java:69)
  at androidx.fragment.app.Fragment.performPause (Fragment.java:3168)
  at androidx.fragment.app.FragmentStateManager.pause (FragmentStateManager.java:632)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState (FragmentStateManager.java:314)
  at androidx.fragment.app.FragmentStore.moveToExpectedState (FragmentStore.java:112)
  at androidx.fragment.app.FragmentManager.moveToState (FragmentManager.java:1647)
  at androidx.fragment.app.FragmentManager.dispatchStateChange (FragmentManager.java:3128)
  at androidx.fragment.app.FragmentManager.dispatchPause (FragmentManager.java:3090)
  at androidx.fragment.app.FragmentController.dispatchPause (FragmentController.java:284)
  at androidx.fragment.app.FragmentActivity.onPause (FragmentActivity.java:390)
  at android.app.Activity.performPause (Activity.java:8778)
  at android.app.Instrumentation.callActivityOnPause (Instrumentation.java:1585)
  at android.app.ActivityThread.performPauseActivityIfNeeded (ActivityThread.java:5707)
```
`MiniPlayerFragment.java:69` is inside of `onPause`, where we clean up and release the media controller. The controller is set from inside of a future callback that we create in `onResume`. The [docs](https://developer.android.com/reference/androidx/media3/session/MediaController.Builder#buildAsync()) state that this future needs to be held by the caller until the future completes. Otherwise, there is a race condition where the future could get garbage collected prior to completion and thus the controller would never be set, leading to a null pointer exception when we get to `onPause`. I wasn't doing that properly before. So I think the fix here is pretty simple:

1. Hang on to a reference to the future inside `MiniPlayerFragment`.
2. Use `MediaController.releaseFuture` instead of `mediaController.release` in `onPause`; the former is nicer in that it ensures the controller will be properly released even if we get to `onPause` before the future has completed (which seems unlikely, but it's still good to do this properly).

# Service did not start in time exception

This one is harder to track down:

```
Exception android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException:
  at android.app.ActivityThread.generateForegroundServiceDidNotStartInTimeException (ActivityThread.java:2245)
  at android.app.ActivityThread.throwRemoteServiceException (ActivityThread.java:2216)
  at android.app.ActivityThread.-$$Nest$mthrowRemoteServiceException
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2508)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8762)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:604)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
Caused by android.app.StackTrace: Last startServiceCommon() call for this service was made here
  at android.app.ContextImpl.startServiceCommon (ContextImpl.java:1988)
  at android.app.ContextImpl.startForegroundService (ContextImpl.java:1933)
  at android.content.ContextWrapper.startForegroundService (ContextWrapper.java:839)
  at android.content.ContextWrapper.startForegroundService (ContextWrapper.java:839)
  at androidx.core.content.ContextCompat$Api26Impl.startForegroundService (ContextCompat.java:1091)
  at androidx.core.content.ContextCompat.startForegroundService (ContextCompat.java:749)
  at androidx.media3.session.MediaButtonReceiver.onReceive (MediaButtonReceiver.java:147)
  at android.app.ActivityThread.handleReceiver (ActivityThread.java:4894)
  at android.app.ActivityThread.-$$Nest$mhandleReceiver
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2420)
```

It appears to only affect Samsung devices, and the play console states that "this crash may be related to an SDK". I'm not exactly sure what they mean by that, but given the device specificity I wonder if Samsung's implementation of some of the Android APIs is buggy or something. The only thing I can really glean from this stack trace is that is has to do with the line `  at androidx.media3.session.MediaButtonReceiver.onReceive (MediaButtonReceiver.java:147)`. I did switch from using `androidx.media.session.MediaButtonReceiver` to `androidx.media3.session.MediaButtonReceiver` in #87 in the effort to update most `media` components to their `media3` equivalents. I don't see a clear reason why this should create a problem, but for lack of other ideas, I've reverted back to `androidx.media.session.MediaButtonReceiver` to see if that fixes the issue.