### PR TITLE
DB Synchronization Patches

### DIFF
--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -157,10 +157,11 @@ public class DBManager extends AbstractDBManager {
                         C.Edition.TABLE_NAME
                 };
                 for (String table: tables) {
-                    db.execSQL("DROP TABLE IF EXISTS main." + table);
-                    db.execSQL("CREATE TABLE main." + table + " AS SELECT * FROM upgradeDb." + table);
+                    db.execSQL("DROP TABLE IF EXISTS " + table);
+                    db.execSQL("CREATE TABLE " + table + " AS SELECT * FROM upgradeDb." + table);
                     Log.i(LOG_TAG, "Copied table " + table + " from asset DB.");
                 }
+                db.setTransactionSuccessful();
                 db.endTransaction();
                 db.execSQL("DETACH upgradeDb");
                 db.beginTransaction();

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -163,6 +163,7 @@ public class DBManager extends AbstractDBManager {
                 }
                 db.endTransaction();
                 db.execSQL("DETACH upgradeDb");
+                db.beginTransaction();
                 Log.i(LOG_TAG, "Successfully transferred all tables from asset DB");
             }
         } catch (IOException e) {
@@ -172,8 +173,6 @@ public class DBManager extends AbstractDBManager {
         }
 
         dbUpgradeFile.delete();
-
-        throw new RuntimeException("Refuse to update!");
     }
 
     @Override

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -160,31 +160,22 @@ public class DBManager extends AbstractDBManager {
     // Insert an item into the database, given the JSON object for an item returned by dharamaseed.org's API
     public void insertItem(String itemID, JSONObject item, String tableName, String[] itemKeys) {
         SQLiteDatabase db = getWritableDatabase();
-        try {
-            ContentValues values = new ContentValues();
-            values.put(C.Talk.ID, itemID);
-            for(String itemKey : itemKeys) {
-                insertValue(values, item, itemKey);
-            }
-
-            db.insertWithOnConflict(tableName, null, values, SQLiteDatabase.CONFLICT_REPLACE);
-
-        } catch (Exception e) {
-            Log.e("DBInsert", e.toString());
+        ContentValues values = new ContentValues();
+        values.put(C.Talk.ID, itemID);
+        for(String itemKey : itemKeys) {
+            insertValue(values, item, itemKey);
         }
+
+        db.insertWithOnConflict(tableName, null, values, SQLiteDatabase.CONFLICT_REPLACE);
     }
 
-    public void insertItems(JSONObject json, String tableName, String[] itemKeys) {
-        try {
-            JSONObject items = json.getJSONObject("items");
-            Iterator<String> it = items.keys();
-            while (it.hasNext()) {
-                String itemID = it.next();
-                JSONObject item = items.getJSONObject(itemID);
-                insertItem(itemID, item, tableName, itemKeys);
-            }
-        } catch (JSONException e) {
-            Log.d("insertItems", e.toString());
+    public void insertItems(JSONObject json, String tableName, String[] itemKeys) throws JSONException {
+        JSONObject items = json.getJSONObject("items");
+        Iterator<String> it = items.keys();
+        while (it.hasNext()) {
+            String itemID = it.next();
+            JSONObject item = items.getJSONObject(itemID);
+            insertItem(itemID, item, tableName, itemKeys);
         }
     }
 

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -148,19 +148,6 @@ public class DBManager extends AbstractDBManager {
         }
     }
 
-    /**
-     * Removes the edition entry for `tableName`
-     * @param db
-     * @param tableName
-     */
-    private void clearEdition(SQLiteDatabase db, String tableName) {
-        ContentValues v = new ContentValues();
-        v.put(C.Edition.TABLE, tableName);
-        v.putNull(C.Edition.EDITION);
-        db.insertWithOnConflict(C.Edition.TABLE_NAME, null, v, SQLiteDatabase.CONFLICT_REPLACE);
-
-    }
-
     private void insertValue(ContentValues values, JSONObject obj, String key) {
         try {
             String value = obj.getString(key);
@@ -218,6 +205,50 @@ public class DBManager extends AbstractDBManager {
             SQLiteDatabase db = getWritableDatabase();
             db.delete(tableName, "_id IN " + idsToDelete, null);
         }
+    }
+
+    /**
+     * Removes the edition entry for `tableName`
+     * @param db
+     * @param tableName
+     */
+    private void clearEdition(SQLiteDatabase db, String tableName) {
+        ContentValues v = new ContentValues();
+        v.put(C.Edition.TABLE, tableName);
+        v.putNull(C.Edition.EDITION);
+        db.insertWithOnConflict(C.Edition.TABLE_NAME, null, v, SQLiteDatabase.CONFLICT_REPLACE);
+
+    }
+
+    /**
+     * Retrieves the edition string for a table in the DB
+     * @param tableName: name of the table
+     */
+    public String getEdition(String tableName) {
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor cursor = db.rawQuery("SELECT "+DBManager.C.Edition.EDITION+" FROM "
+                        +DBManager.C.Edition.TABLE_NAME
+                        +" WHERE "+DBManager.C.Edition.TABLE+"=\""+tableName+"\""
+                , null);
+        String edition = "";
+        if (cursor.moveToFirst()) {
+            edition = cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Edition.EDITION));
+        }
+        cursor.close();
+        return edition;
+    }
+
+    /**
+     * Sets the edition string for a table in the DB
+     * @param tableName: name of the table
+     * @param newEdition: the new edition of the table
+     */
+    public void setEdition(String tableName, String newEdition) {
+        SQLiteDatabase db = getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put(DBManager.C.Edition.TABLE, tableName);
+        values.put(DBManager.C.Edition.EDITION, newEdition);
+        db.insertWithOnConflict(DBManager.C.Edition.TABLE_NAME, null, values, SQLiteDatabase.CONFLICT_REPLACE);
     }
 
     public static String getTeacherPhotoFilename(int teacherID) {

--- a/app/src/main/java/org/dharmaseed/android/DataFetcherTask.java
+++ b/app/src/main/java/org/dharmaseed/android/DataFetcherTask.java
@@ -60,7 +60,6 @@ abstract class DataFetcherTask extends AsyncTask<Void, Void, Void> {
     protected void updateTable(String tableName, String tableID, String apiUrl, String[] itemKeys) {
 
         String edition = dbManager.getEdition(tableName);
-//        String edition = "2012-11-04 20:23:59"; //cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Edition.EDITION));
         Log.d(LOG_TAG, "We have "+tableName+" edition: "+edition);
 
         // Get the IDs (but no details) of the items we don't yet have


### PR DESCRIPTION
This pull request addresses [issue 89](https://github.com/dharmaseed/dharmaseed-android/issues/89), where the some of the information displayed by the app was found to be out-of-sync with the dharmaseed site.

Two likely contributing causes of the problems were:
- Updated items were being correctly indicated in the responses from the dharmaseed.org HTTP API but subsequently filtered out by the `if(keyExists(ID))` filter in [org.dharmaseed.android.DataFetcherTask.RequestAggregator#addID](https://github.com/intermarc/dharmaseed-android/blob/4dfbde1702a1d1065241448e5fcecf6dcbc1214e/app/src/main/java/org/dharmaseed/android/DataFetcherTask.java#L189)
- The app receives database updates to several tables concurrently. The concurrent-access errors that this might have caused would have been caught and ignored, however, such that DB updates would appear to have been successful despite errors. More information on this point is included in the discussion of the original issue (see link above).

The patches change the existing functionality as follows:
- Updated items supplied by the dharmaseed API are no longer filtered out
- Exceptions during DB update are propagated further up the stack, such that the DB edition recorded by the app is only changed for exception-free updates.

In addition, changes to the `DBManager` upgrade process can be used to roll out updated DB tables to all users (not just those with new installs of the app). The old behavior was to install the DB shipped in the app assets for new installs only. The change implemented in this branch is to copy the talks, teachers and centers tables from the assets DB for all users _if_ `DBManager.DB_VERSION` is incremented  _and_ the asset DB shipped with the app already has the new `DB_VERSION` number. This happens in [org.dharmaseed.android.DBManager#onUpgrade](https://github.com/intermarc/dharmaseed-android/blob/144399a8847a067900debd60634e11c75234d8e7/app/src/main/java/org/dharmaseed/android/DBManager.java#L132). The added functionality effectively allows us to roll out new versions of the tables containing the dharmaseed.org information by incrementing `DB_VERSION` and bundling an asset DB with the new version.

The updated `DBManager` class includes an incremented `DB_VERSION` (from 2 to 3) as well as an up-to-date assets DB that is in sync with dharmaseed.org.

 This strategy for shipping out table updates might come in handy in future, too. For instance, when we start supporting multiple teachers in one talk, we could just update the assets DB and increment DB_VERSION to roll out the change. Another feature of this approach is that the user-specific tables with talk/teacher stars and talk progress are preserved during the update.