### PR TITLE
Add crashlytics app monitoring

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,15 @@
  *
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+
+    // Crash reporting
+    id 'com.google.gms.google-services'
+    id 'com.google.firebase.crashlytics'
+}
+
+
 
 android {
     compileSdkVersion 33
@@ -58,4 +66,13 @@ dependencies {
     androidTestImplementation 'androidx.test:core:1.5.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:runner:1.5.2'
+
+    // Import the BoM for the Firebase platform
+    implementation(platform("com.google.firebase:firebase-bom:32.5.0"))
+
+    // Add the dependencies for the Crashlytics and Analytics libraries
+    // When using the BoM, you don't specify versions in Firebase library dependencies
+    implementation("com.google.firebase:firebase-crashlytics")
+    implementation("com.google.firebase:firebase-analytics")
+
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,8 +34,8 @@ android {
         applicationId "org.dharmaseed.android"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 23
-        versionName "1.5.2"
+        versionCode 25
+        versionName "1.5.3"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/app/src/google-services.json
+++ b/app/src/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "180270825004",
+    "project_id": "dharmaseed-6fc56",
+    "storage_bucket": "dharmaseed-6fc56.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:180270825004:android:0f0e206cd0d7db2aad5b89",
+        "android_client_info": {
+          "package_name": "org.dharmaseed.android"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDNExaUp1tolZI5I9erdnQ3-ELEfsriZh8"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         tools:ignore="ScopedStorage" /> <!-- For keeping android from killing our app when playing talks in the background with screen off -->
     <uses-permission android:name="android.permission.WAKE_LOCK" /> <!-- For displaying a notification to the user when a talk is playing -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" /> <!-- For firebase crashlytics -->
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
@@ -40,6 +40,8 @@ import android.widget.EditText;
 import android.util.Log;
 import android.view.View;
 import com.google.android.material.navigation.NavigationView;
+import com.google.firebase.analytics.FirebaseAnalytics;
+
 import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.appcompat.app.ActionBarDrawerToggle;
@@ -108,6 +110,8 @@ public class NavigationActivity extends AppCompatActivity
     private TeacherRepository teacherRepository;
     private CenterRepository centerRepository;
 
+    private FirebaseAnalytics mFirebaseAnalytics;
+
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
@@ -167,6 +171,8 @@ public class NavigationActivity extends AppCompatActivity
 //            StrictMode.setVmPolicy(policy);
 //        }
 
+        // Initialize firebase crash reporting
+        mFirebaseAnalytics = FirebaseAnalytics.getInstance(this);
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_navigation);

--- a/build.gradle
+++ b/build.gradle
@@ -19,24 +19,13 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-buildscript {
-    repositories {
-        jcenter()
-        google()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+plugins {
+    id 'com.android.application' version '8.1.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        jcenter()
-        google()
-    }
+    // Crash reporting
+    id 'com.google.gms.google-services' version '4.4.0' apply false
+    id 'com.google.firebase.crashlytics' version '2.9.9' apply false
 }
 
 task clean(type: Delete) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,4 +17,20 @@
  *
  */
 
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        google()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'


### PR DESCRIPTION
In my ongoing efforts to understand the causes of some crashes we've been seeing in production since the release of #87, I've learned that the reporting in the google play console, which so far has been the way I've been learning about the crashes, can be [somewhat incomplete](https://stackoverflow.com/a/33305362) in the data it is able to capture. This PR adds support for [crashlytics](https://firebase.google.com/products/crashlytics/), which from my research should be a more complete solution for error reporting.

I couldn't really think of a better way to test the value of this solution other than releasing a public version of the app with crashlytics configured and seeing whether the data we got back was useful, so I made a release a week or so ago and gave crashlytics time to collect some data. I do think it's providing useful insights, such as the 96% of the most commonly occurring error is showing up on Samsung devices, which confirms some reports I've seen from other apps that have had trouble switching to the new android media framework.

Given that crashlytics seems to provide some useful debugging data, I think we should merge this support along with #90 before we make our next public release.

Implementation wise, this PR is pretty straightforward; I just followed the instructions [here](https://firebase.google.com/docs/crashlytics/get-started?platform=android) for adding crashlytics to an Android app. The only small catch was realizing that we were using an old and no longer recommended build script syntax, so I also followed [these instructions](https://developer.android.com/build/migrate-to-kotlin-dsl) to update the syntax. But other than adding the crashlytics libraries, there should be no other functional changes to the app as a result of this PR.
