### PR TITLE
Upgrade android media library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,12 +20,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
 
     defaultConfig {
         applicationId "org.dharmaseed.android"
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdk 21
+        compileSdk 34
+        targetSdk 34
         versionCode 23
         versionName "1.5.2"
         vectorDrawables.useSupportLibrary = true
@@ -48,9 +48,9 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.2'
 
     // Exoplayer stuff
-    implementation 'androidx.media3:media3-exoplayer:1.1.1'
-    implementation 'androidx.media3:media3-ui:1.1.1'
-    implementation "androidx.media3:media3-session:1.1.1"
+    implementation 'androidx.media3:media3-exoplayer:1.2.0'
+    implementation 'androidx.media3:media3-ui:1.2.0'
+    implementation "androidx.media3:media3-session:1.2.0"
 
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'junit:junit:4.13.2'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.10.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.2'
 
     // Exoplayer stuff

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         tools:ignore="ScopedStorage" /> <!-- For keeping android from killing our app when playing talks in the background with screen off -->
     <uses-permission android:name="android.permission.WAKE_LOCK" /> <!-- For displaying a notification to the user when a talk is playing -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
A new version, 1.2.0, of the android media library was [just released](https://github.com/androidx/media/releases/tag/1.2.0). This release includes several fixes that are relevant to https://github.com/androidx/media/issues/167, which seems to be the root cause of some issues we've been seeing in production, particularly on Samsung devices. Among many other changes, the release notes for 1.2.0 say this: "Use only android.media.session.MediaSession.setMediaButtonBroadcastReceiver() above API 31 to avoid problems with deprecated API on Samsung devices (https://github.com/androidx/media/issues/167)." I'm hopeful that upgrading to 1.2.0 will resolve our issues in production. We'll be able to monitor the impact of the upgrade using crashlytics (see #91).

Upgrading to 1.2.0 also required upgrading our `targetSdk` to version 34. This was straightforward, it just required adding one more permission that is now required by Android for playing media in a foreground service. I also updated the `com.google.android.material` library for good measure as it was slightly out of date; this shouldn't have any noticeable impact.

