### PR TITLE
Support for multiple teachers per talk

### DIFF
--- a/app/src/androidTest/assets/inserts.txt
+++ b/app/src/androidTest/assets/inserts.txt
@@ -1,5 +1,6 @@
 CREATE TABLE talks (_id INTEGER PRIMARY KEY,title TEXT,description TEXT,venue_id INTEGER,teacher_id INTEGER,audio_url TEXT,duration_in_minutes REAL,update_date TEXT,rec_date TEXT,retreat_id INTEGER,file_path TEXT NOT NULL DEFAULT '');
 CREATE TABLE teachers (_id INTEGER PRIMARY KEY,website TEXT,bio TEXT,name TEXT,public INTEGER,monastic INTEGER,photo TEXT);
+CREATE TABLE talk_teachers (_id INTEGER,teacher_id INTEGER);
 CREATE TABLE centers (_id INTEGER PRIMARY KEY,website TEXT,description TEXT,name TEXT);
 CREATE TABLE talk_stars (_id INTEGER PRIMARY KEY);
 CREATE TABLE teacher_stars (_id INTEGER PRIMARY KEY);
@@ -12,7 +13,7 @@ when our experience is difficult or unpleasant.',1,153,'/teacher/153/talk/1/1990
 INSERT INTO "talks" VALUES(2,'How This Practice Works','This talk presents the technical, meditative practice of mindfulness
 and LovingKindness in the context of the fullest sense of practice,
 the living of an awakened, purposeful life.  If you are living
-intentionally, you can''t be practicing wrong.',1,174,'/teacher/174/talk/2/19900101-Sylvia_Boorstein-UNK-how_this_practice_works-2.mp3',57.3373333333333,'2018-02-27 00:15:17','1990-01-01 00:00:00',1,'');
+intentionally, you can''t be practicing wrong.',1,174,'/teacher/174/talk/2/19900101-Sylvia_Boorstein-UNK-how_this_practice_works-2.mp3',57.3373333333333,'2018-02-27 00:15:17','1990-01-01 00:00:01',1,'');
 INSERT INTO "talks" VALUES(4,'Seven Factors Of Enlightenment','Developing and balancing the seven factors of awakening [mindfulness,
 investigation, energy, joy, calm, concentration and equanimity] to
 support life and practice.',1,3,'/teacher/3/talk/4/20011011-Adrianne_Ross-UNK-seven_factors_of_enlightenment-4.mp3',53.6806666666667,'2018-02-27 00:17:56','2001-10-11 00:00:00',1,'');
@@ -33,7 +34,9 @@ value and right use of reflective thinking.',1,4,'/teacher/4/talk/9/19980414-Aja
 INSERT INTO "talks" VALUES(11,'The Power Of Metta','Lovingkindness is the quality of friendliness toward oneself and others^M
 developed through the practice of metta.  This talk describes how the^M
 practice works as a protection, a healing, a purification of heart, and a^M
-boundless state of mind.',1,79,'/teacher/79/talk/11/20010706-Guy_Armstrong-UNK-the_power_of_metta-11.mp3',48.1608333333333,'2018-02-27 00:30:56','2001-07-06 00:00:00',1,'');
+boundless state of mind.',1,79,'/teacher/79/talk/11/20010706-Guy_Armstrong-UNK-the_power_of_metta-11.mp3',48.1608333333333,'2018-02-27 00:30:56','2001-07-06 00:00:01',1,'');
+INSERT INTO "talks" VALUES(78560,'Chanting the Fire Sermon','Chanting',242,278,'/talks/78560/20230626-Ayya_Santacitta-BCBS-chanting_the_fire_sermon-78560.mp3',12.718972789115646548,'2023-06-26 01:06:46','2023-06-26 01:05:32',5583,'');
+INSERT INTO "talks" VALUES(78598,'The Highest Blessings Chant','',242,553,'/talks/78598/20230628-Ayya_Santussika-BCBS-the_highest_blessings_chant-78598.mp3',26.192498866213153262,'2023-06-28 19:10:35','2023-06-28 19:08:13',5583,'');
 INSERT INTO "teachers" VALUES(96,'http://www.dharma.org/joseph-goldstein','I have two main aims in teaching. The first is to spread the dharma as widely as possible, offering it to as many different people as I can.  The second is to teach a smaller number of people over sustained periods of time. This in-depth teaching engages my tremendous love for intensive, long-term meditation practice, where people can immerse themselves in the retreat experience and see how it transforms their understanding.
 
 
@@ -69,8 +72,11 @@ Right now I''m most enthusiastic about the first gift, paying attention, because
 
 As a parent, grandparent and a psychotherapist, I teach out of the stories of my life and the lives of those around me.  I am especially touched by personal narrative, accounts of spiritual journeys, and how these become vehicles for connecting with the dharma.  I believe in revealing my own story so that others are more at ease to reveal theirs.  Truth talking is a way out of suffering.  Discovering how our hearts and minds work and creating a dialogue supports right speech practice.  This is an on-going primary practice that we can do all the time.  My hope is that I encourage people how to pay attention and to tell the truth by example.
 ','Sylvia Boorstein','true','false','photo.png');
+INSERT INTO "teachers" VALUES(278,'https://alokavihara.org/aloka-earth-room/','Santacitta Bhikkhuni hails from Austria and trained as a nun in England & Asia from 1993 until 2009, primarily in the lineage of Ajahn Chah. Since 2002, she has also received teachings in the lineage of Dilgo Khyentse Rinpoche. She is committed to our planet as a living being and resides at ''Aloka Earth Room'', currently located in San Rafael, California. Santacitta Bhikkhuni stammt aus Österreich and begann ihre Nonnenausbildung 1993 in England & Asien, vor allem in der Traditionslinie von Ajahn Chah. Seit 2002 empfängt sie auch Unterweisungen in der Traditionslinie von Dilgo Khyentse Rinpoche. Sie ist unserem Planeten als lebendes Wesen verpflichtet und lebt im ''Aloka Earth Room'' in San Rafael, Kalifornien.','Ayya Santacitta','true','true','photo.png');
+INSERT INTO "teachers" VALUES(553,'http://www.karunabv.org/',replace(replace('Ayya Santussika, in residence at Karuna Buddhist Vihara (Compassion Monastery), spent five years as an anagarika (eight-precept nun), then ordained as a samaneri (ten-precept nun) in 2010 and as a bhikkhuni (311 rules) in 2012 at Dharma Vijaya Buddhist Vihara in Los Angeles. \r\n\r\nAyya Santussika was born in Illinos in 1954 and grew up on a farm in Indiana. While being a single mother, she received BS and MS degrees in computer science and moved with her two children to the San Francisco Bay Area. She worked as a software designer and developer for fifteen years. Her search for deeper meaning and ways to be of service led her to train as an interfaith minister in a four-year seminary program that culminated in an Masters of Divinity degree and a brief period of practice as a minister before ordaining as a Buddhist nun. She is currently serving on the Board of Directors for Buddhist Global Relief.','\r',char(13)),'\n',char(10)),'Ayya Santussika','true','true','photo.png');
 INSERT INTO "centers" VALUES(3,'http://www.dharma.org','IMS is a spiritual refuge for all who seek freedom from the suffering of mind and heart. We offer meditation retreats rooted in the Theravada Buddhist teachings of ethics, concentration and wisdom. These practices help develop awareness and compassion, giving rise to greater peace and happiness in the world.','Insight Meditation Society - Forest Refuge');
 INSERT INTO "centers" VALUES(6,'http://www.dharma.org','IMS is a spiritual refuge for all who seek freedom from the suffering of mind and heart. We offer meditation retreats rooted in the Theravada Buddhist teachings of ethics, concentration and wisdom. These practices help develop awareness and compassion, giving rise to greater peace and happiness in the world.','Insight Meditation Society - Retreat Center');
+INSERT INTO "centers" VALUES(242,'https://www.buddhistinquiry.org/',replace(replace('The Barre Center for Buddhist Studies is a non-profit educational organization dedicated to exploring Buddhist thought and practice as a living tradition, faithful to its origins, yet adaptable to the current world. The center provides a bridge between study and practice, between scholarly understanding and meditative insight. It encourages engagement with the tradition in a spirit of genuine inquiry.\r\n\r\nThe study center offers a variety of courses, workshops, retreats, and self-study programs to further research, study, and practice. Our programming is rooted in the classical Buddhist tradition of the earliest teachings and practices, but calls for dialogue with other schools of Buddhism and with other academic fields. All courses support both silent meditation practice and conscious investigation of the teachings.','\r',char(13)),'\n',char(10)),'Barre Center for Buddhist Studies');
 INSERT INTO "downloaded_talks" VALUES(6);
 INSERT INTO "downloaded_talks" VALUES(9);
 INSERT INTO "downloaded_talks" VALUES(11);
@@ -82,3 +88,17 @@ INSERT INTO "talks" VALUES(46,'Opening Talk','',6,96,'/teacher/96/talk/46/200602
 INSERT INTO "talks" VALUES(47,'Wisdom & Compassion','',6,96,'/teacher/96/talk/47/20060208-Joseph_Goldstein-IMSRC-wisdom_compassion-47.mp3',59.366667,'2011-07-24 22:28:52','2006-02-08 00:00:00',3813,'');
 INSERT INTO "talk_stars" VALUES(46);
 INSERT INTO "centers" VALUES(1,'','','Unknown');
+
+INSERT INTO "talk_teachers" VALUES(1,153);
+INSERT INTO "talk_teachers" VALUES(2,174);
+INSERT INTO "talk_teachers" VALUES(4,3);
+INSERT INTO "talk_teachers" VALUES(5,46);
+INSERT INTO "talk_teachers" VALUES(6,96);
+INSERT INTO "talk_teachers" VALUES(8,193);
+INSERT INTO "talk_teachers" VALUES(9,4);
+INSERT INTO "talk_teachers" VALUES(11,79);
+INSERT INTO "talk_teachers" VALUES(46,96);
+INSERT INTO "talk_teachers" VALUES(47,96);
+INSERT INTO "talk_teachers" VALUES(78560,278);
+INSERT INTO "talk_teachers" VALUES(78560,553);
+INSERT INTO "talk_teachers" VALUES(78598,553);

--- a/app/src/androidTest/java/org/dharmaseed/android/TalkRepositoryTest.java
+++ b/app/src/androidTest/java/org/dharmaseed/android/TalkRepositoryTest.java
@@ -82,6 +82,7 @@ public class TalkRepositoryTest
                 " AS talks_duration_in_minutes, talks.retreat_id AS talks_retreat_id FROM talks ORDER BY talks" +
                 ".rec_date DESC", null);
 
+        assertEquals(12, actualCursor.getCount());
         assertCursors(expectedCursor, actualCursor, allTalkColumns);
     }
 
@@ -359,7 +360,15 @@ public class TalkRepositoryTest
                     "ORDER BY rec_date DESC",
                 null);
 
+        assertEquals(3, actual.getCount());
         assertCursors(expected, actual, columns);
+
+        // Make sure that talks with more than one teacher are correctly returned by getTalksByTeacher
+        actual = talkRepository.getTalksByTeacher(null, 278, false, false);
+        assertEquals(1, actual.getCount());
+
+        actual = talkRepository.getTalksByTeacher(null, 553, false, false);
+        assertEquals(2, actual.getCount());
     }
 
     @Test

--- a/app/src/main/java/org/dharmaseed/android/AbstractDBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/AbstractDBManager.java
@@ -98,13 +98,11 @@ public abstract class AbstractDBManager extends SQLiteOpenHelper {
         }
 
         // Talks can have multiple teachers associated with them.
-        // This table holds IDs for any extra teachers associated with a talk.
-        // We don't include the ID of the primary teacher in this table, since that is already
-        // captured in the Talk table.
-        public abstract class ExtraTalkTeachers {
+        // This table holds IDs for all teachers associated with each talk.
+        public abstract class TalkTeachers {
             public static final String TALK_ID = "_id";
             public static final String TEACHER_ID = "teacher_id";
-            public static final String TABLE_NAME = "extra_talk_teachers";
+            public static final String TABLE_NAME = "talk_teachers";
             public static final String CREATE_TABLE = "CREATE TABLE " + TABLE_NAME + " (" + TALK_ID + " INTEGER,"
                     + TEACHER_ID + " INTEGER)";
         }

--- a/app/src/main/java/org/dharmaseed/android/AbstractDBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/AbstractDBManager.java
@@ -97,6 +97,18 @@ public abstract class AbstractDBManager extends SQLiteOpenHelper {
             public static final String DROP_TABLE = "DROP TABLE IF EXISTS " + TABLE_NAME;
         }
 
+        // Talks can have multiple teachers associated with them.
+        // This table holds IDs for any extra teachers associated with a talk.
+        // We don't include the ID of the primary teacher in this table, since that is already
+        // captured in the Talk table.
+        public abstract class ExtraTalkTeachers {
+            public static final String TALK_ID = "_id";
+            public static final String TEACHER_ID = "teacher_id";
+            public static final String TABLE_NAME = "extra_talk_teachers";
+            public static final String CREATE_TABLE = "CREATE TABLE " + TABLE_NAME + " (" + TALK_ID + " INTEGER,"
+                    + TEACHER_ID + " INTEGER)";
+        }
+
         public abstract class Teacher {
             public static final String WEBSITE = "website";
             public static final String DONATION_URL = "donation_url";

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -103,7 +103,7 @@ public class DBManager extends AbstractDBManager {
     @Override
     public void onCreate(SQLiteDatabase db) {
         db.execSQL(C.Talk.CREATE_TABLE);
-        db.execSQL(C.ExtraTalkTeachers.CREATE_TABLE);
+        db.execSQL(C.TalkTeachers.CREATE_TABLE);
         db.execSQL(C.Teacher.CREATE_TABLE);
         db.execSQL(C.Center.CREATE_TABLE);
         db.execSQL(C.Retreat.CREATE_TABLE);
@@ -141,8 +141,8 @@ public class DBManager extends AbstractDBManager {
             Log.i(LOG_TAG,"Upgrade: Created talk history table");
         }
         if (oldVersion == 3 && newVersion > 3) {
-            db.execSQL(C.ExtraTalkTeachers.CREATE_TABLE);
-            Log.i(LOG_TAG,"Upgrade: Created extra talk teachers table");
+            db.execSQL(C.TalkTeachers.CREATE_TABLE);
+            Log.i(LOG_TAG,"Upgrade: Created talk teachers table");
         }
 
         // Optionally import updated tables from the assets DB.
@@ -161,7 +161,7 @@ public class DBManager extends AbstractDBManager {
                 db.execSQL("ATTACH DATABASE '" + dbUpgradePath + "' AS upgradeDb");
                 String[][] t_info = {
                         {C.Talk.TABLE_NAME, C.Talk.CREATE_TABLE},
-                        {C.ExtraTalkTeachers.TABLE_NAME, C.ExtraTalkTeachers.CREATE_TABLE},
+                        {C.TalkTeachers.TABLE_NAME, C.TalkTeachers.CREATE_TABLE},
                         {C.Teacher.TABLE_NAME, C.Teacher.CREATE_TABLE},
                         {C.Center.TABLE_NAME, C.Center.CREATE_TABLE},
                         {C.Edition.TABLE_NAME, C.Edition.CREATE_TABLE}

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -140,7 +140,7 @@ public class DBManager extends AbstractDBManager {
             db.execSQL(C.TalkHistory.CREATE_TABLE);
             Log.i(LOG_TAG,"Upgrade: Created talk history table");
         }
-        if (oldVersion == 3 && newVersion > 3) {
+        if (oldVersion <= 3 && newVersion > 3) {
             db.execSQL(C.TalkTeachers.CREATE_TABLE);
             Log.i(LOG_TAG,"Upgrade: Created talk teachers table");
         }

--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -35,6 +35,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -44,7 +45,7 @@ import java.util.List;
  */
 public class DBManager extends AbstractDBManager {
 
-    private static final int DB_VERSION = 3;
+    private static final int DB_VERSION = 4;
     private static final String DB_NAME = "Dharmaseed.db";
     private static final String LOG_TAG = "DBManager";
 
@@ -102,6 +103,7 @@ public class DBManager extends AbstractDBManager {
     @Override
     public void onCreate(SQLiteDatabase db) {
         db.execSQL(C.Talk.CREATE_TABLE);
+        db.execSQL(C.ExtraTalkTeachers.CREATE_TABLE);
         db.execSQL(C.Teacher.CREATE_TABLE);
         db.execSQL(C.Center.CREATE_TABLE);
         db.execSQL(C.Retreat.CREATE_TABLE);
@@ -138,6 +140,10 @@ public class DBManager extends AbstractDBManager {
             db.execSQL(C.TalkHistory.CREATE_TABLE);
             Log.i(LOG_TAG,"Upgrade: Created talk history table");
         }
+        if (oldVersion == 3 && newVersion > 3) {
+            db.execSQL(C.ExtraTalkTeachers.CREATE_TABLE);
+            Log.i(LOG_TAG,"Upgrade: Created extra talk teachers table");
+        }
 
         // Optionally import updated tables from the assets DB.
         // This should be the last step in onUpgrade, to ensure that we don't encounter any problem
@@ -155,6 +161,7 @@ public class DBManager extends AbstractDBManager {
                 db.execSQL("ATTACH DATABASE '" + dbUpgradePath + "' AS upgradeDb");
                 String[][] t_info = {
                         {C.Talk.TABLE_NAME, C.Talk.CREATE_TABLE},
+                        {C.ExtraTalkTeachers.TABLE_NAME, C.ExtraTalkTeachers.CREATE_TABLE},
                         {C.Teacher.TABLE_NAME, C.Teacher.CREATE_TABLE},
                         {C.Center.TABLE_NAME, C.Center.CREATE_TABLE},
                         {C.Edition.TABLE_NAME, C.Edition.CREATE_TABLE}
@@ -244,6 +251,12 @@ public class DBManager extends AbstractDBManager {
             SQLiteDatabase db = getWritableDatabase();
             db.delete(tableName, "_id IN " + idsToDelete, null);
         }
+    }
+
+    public void deleteID(Integer id, String tableName) {
+        ArrayList<Integer> ids = new ArrayList<>();
+        ids.add(id);
+        deleteIDs(ids, tableName);
     }
 
     /**

--- a/app/src/main/java/org/dharmaseed/android/DataFetcherTask.java
+++ b/app/src/main/java/org/dharmaseed/android/DataFetcherTask.java
@@ -27,6 +27,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
@@ -106,7 +107,7 @@ abstract class DataFetcherTask extends AsyncTask<Void, Void, Void> {
                 for(Integer id : itemIDs) {
                     itemsWithDetails = agg.addID(id);
                     if(itemsWithDetails != null) {
-                        dbManager.insertItems(itemsWithDetails, tableName, itemKeys);
+                        insertItems(itemsWithDetails, tableName, itemKeys);
                         publishProgress();
                     }
                 }
@@ -114,7 +115,7 @@ abstract class DataFetcherTask extends AsyncTask<Void, Void, Void> {
                     // Fire any last requests still in the aggregator
                     itemsWithDetails = agg.fireRequest();
                     if(itemsWithDetails != null) {
-                        dbManager.insertItems(itemsWithDetails, tableName, itemKeys);
+                        insertItems(itemsWithDetails, tableName, itemKeys);
                     }
                 }
 
@@ -128,6 +129,18 @@ abstract class DataFetcherTask extends AsyncTask<Void, Void, Void> {
         } catch (Exception e) {
             Log.e(LOG_TAG, e.toString());
         }
+    }
+
+    // Inserts items retrieved from the dharmaseed API into the database,
+    // additionally running any table-specific processing tasks
+    protected void insertItems(JSONObject itemsWithDetails, String tableName, String[] itemKeys) throws JSONException {
+        dbManager.insertItems(itemsWithDetails, tableName, itemKeys);
+        extraTableProcessing(dbManager, itemsWithDetails.getJSONObject("items"));
+    }
+
+    // Overridable method to do any additional processing of items returned by the dharmaseed API.
+    // Does nothing by default.
+    protected void extraTableProcessing(DBManager dbManager, JSONObject items) throws JSONException {
     }
 
     @Override

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -117,17 +117,8 @@ public class PlayTalkActivity extends AppCompatActivity
         // for example, if the user selects a talk, exits, and re-opens it, no need
         // to hit the DB again, since we already have that talk saved
         if (talk == null || talk.getId() != talkID) {
-            Cursor cursor = getCursor(dbManager, talkID);
-            if (cursor.moveToFirst()) {
-                // convert DB result to an object
-                talk = new Talk(cursor, getApplicationContext());
-                talk.setId(talkID);
-            } else {
-                Log.e(LOG_TAG, "Could not look up talk, id=" + talkID);
-                cursor.close();
-                return;
-            }
-            cursor.close();
+            talk = Talk.lookup(dbManager, getApplicationContext(), talkID);
+
         } // else we already have the talk, just re-draw the page
 
         // Set the talk title
@@ -316,54 +307,6 @@ public class PlayTalkActivity extends AppCompatActivity
         return mediaController != null &&
                 mediaController.getCurrentMediaItem() != null &&
                 Integer.parseInt(mediaController.getCurrentMediaItem().mediaId) == talkID;
-    }
-
-    public static Cursor getCursor(DBManager dbManager, int talkID) {
-
-        SQLiteDatabase db = dbManager.getReadableDatabase();
-        String query = String.format(
-                "SELECT %s, %s.%s, %s, %s, %s, %s, %s, %s, %s, %s.%s AS teacher_name, %s.%s AS center_name, "
-                        + "%s.%s FROM %s, %s, %s WHERE %s.%s=%s.%s AND %s.%s=%s.%s AND %s.%s=%s",
-                DBManager.C.Talk.TITLE,
-                DBManager.C.Talk.TABLE_NAME,
-                DBManager.C.Talk.DESCRIPTION,
-                DBManager.C.Talk.AUDIO_URL,
-                DBManager.C.Talk.DURATION_IN_MINUTES,
-                DBManager.C.Talk.RECORDING_DATE,
-                DBManager.C.Talk.UPDATE_DATE,
-                DBManager.C.Talk.RETREAT_ID,
-                DBManager.C.Talk.FILE_PATH,
-                DBManager.C.Talk.TEACHER_ID,
-                DBManager.C.Teacher.TABLE_NAME,
-                DBManager.C.Teacher.NAME,
-                DBManager.C.Center.TABLE_NAME,
-                DBManager.C.Center.NAME,
-
-                DBManager.C.Teacher.TABLE_NAME,
-                DBManager.C.Teacher.ID,
-
-                // FROM
-                DBManager.C.Talk.TABLE_NAME,
-                DBManager.C.Teacher.TABLE_NAME,
-                DBManager.C.Center.TABLE_NAME,
-
-                // WHERE
-                DBManager.C.Talk.TABLE_NAME,
-                DBManager.C.Talk.TEACHER_ID,
-                DBManager.C.Teacher.TABLE_NAME,
-                DBManager.C.Teacher.ID,
-
-                DBManager.C.Talk.TABLE_NAME,
-                DBManager.C.Talk.VENUE_ID,
-                DBManager.C.Center.TABLE_NAME,
-                DBManager.C.Center.ID,
-
-                DBManager.C.Talk.TABLE_NAME,
-                DBManager.C.Talk.ID,
-                talkID
-        );
-
-        return db.rawQuery(query, null);
     }
 
     @Override

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -27,8 +27,6 @@ import android.graphics.drawable.Animatable;
 import android.os.AsyncTask;
 
 import android.content.Intent;
-import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
 import android.media.AudioManager;
@@ -56,11 +54,7 @@ import androidx.media3.session.SessionToken;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.Timer;
@@ -127,7 +121,7 @@ public class PlayTalkActivity extends AppCompatActivity
 
         // Set the teacher name
         TextView teacherView = (TextView) findViewById(R.id.play_talk_teacher);
-        teacherView.setText(talk.getAllTeachers());
+        teacherView.setText(talk.getAllTeacherNamesString());
 
         // Set the center name
         TextView centerView = (TextView) findViewById(R.id.play_talk_center);

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -127,7 +127,7 @@ public class PlayTalkActivity extends AppCompatActivity
 
         // Set the teacher name
         TextView teacherView = (TextView) findViewById(R.id.play_talk_teacher);
-        teacherView.setText(talk.getTeacherName());
+        teacherView.setText(talk.getAllTeachers());
 
         // Set the center name
         TextView centerView = (TextView) findViewById(R.id.play_talk_center);
@@ -135,16 +135,7 @@ public class PlayTalkActivity extends AppCompatActivity
 
         // Set the talk description
         TextView descriptionView = (TextView) findViewById(R.id.play_talk_talk_description);
-        String header = "";
-        if (talk.getExtraTeacherNames().size() > 0) {
-            header = "Additional teachers:\n";
-            for (String extraTeacherName : talk.getExtraTeacherNames()) {
-                header += extraTeacherName + "\n";
-
-            }
-            header += "\n";
-        }
-        descriptionView.setText(header + talk.getDescription());
+        descriptionView.setText(talk.getDescription());
 
         // Set teacher photo
         String photoFilename = talk.getPhotoFileName();
@@ -161,14 +152,7 @@ public class PlayTalkActivity extends AppCompatActivity
 
         // Set date
         TextView dateView = (TextView) findViewById(R.id.play_talk_date);
-        String recDate = talk.getDate();
-        SimpleDateFormat parser = new SimpleDateFormat(DATE_FORMAT);
-        try {
-            dateView.setText(DateFormat.getDateInstance().format(parser.parse(recDate)));
-        } catch (ParseException e) {
-            dateView.setText("");
-            Log.w(LOG_TAG, "Could not parse talk date for talk ID " + talkID);
-        }
+        dateView.setText(talk.getDate());
 
         // set the image of the download button based on whether the talk is
         // downloaded or not

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -121,7 +121,7 @@ public class PlayTalkActivity extends AppCompatActivity
 
         // Set the teacher name
         TextView teacherView = (TextView) findViewById(R.id.play_talk_teacher);
-        teacherView.setText(talk.getAllTeacherNamesString());
+        teacherView.setText(talk.getAllTeacherNames());
 
         // Set the center name
         TextView centerView = (TextView) findViewById(R.id.play_talk_center);

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -78,8 +78,6 @@ public class PlayTalkActivity extends AppCompatActivity
 
     static final String LOG_TAG = "PlayTalkActivity";
 
-    protected static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
-
     // request code for writing external storage (the number is arbitrary)
     static final int PERMISSIONS_WRITE_EXTERNAL_STORAGE = 9087;
 

--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -135,7 +135,16 @@ public class PlayTalkActivity extends AppCompatActivity
 
         // Set the talk description
         TextView descriptionView = (TextView) findViewById(R.id.play_talk_talk_description);
-        descriptionView.setText(talk.getDescription());
+        String header = "";
+        if (talk.getExtraTeacherNames().size() > 0) {
+            header = "Additional teachers:\n";
+            for (String extraTeacherName : talk.getExtraTeacherNames()) {
+                header += extraTeacherName + "\n";
+
+            }
+            header += "\n";
+        }
+        descriptionView.setText(header + talk.getDescription());
 
         // Set teacher photo
         String photoFilename = talk.getPhotoFileName();

--- a/app/src/main/java/org/dharmaseed/android/PlaybackService.java
+++ b/app/src/main/java/org/dharmaseed/android/PlaybackService.java
@@ -174,18 +174,8 @@ public class PlaybackService extends MediaSessionService {
 
                 // Look up talk from its ID
                 int talkID = Integer.parseInt(item.mediaId);
-                Cursor cursor = PlayTalkActivity.getCursor(
-                        DBManager.getInstance(PlaybackService.this), talkID);
-                if (cursor.moveToFirst()) {
-                    // convert DB result to an object
-                    talk = new Talk(cursor, getApplicationContext());
-                    talk.setId(talkID);
-                } else {
-                    Log.e(LOG_TAG, "Could not look up talk, id=" + talkID);
-                    cursor.close();
-                    continue;
-                }
-                cursor.close();
+                talk = Talk.lookup(DBManager.getInstance(PlaybackService.this),
+                        getApplicationContext(), talkID);
 
                 // Look up teacher photo
                 String photoFilename = talk.getPhotoFileName();

--- a/app/src/main/java/org/dharmaseed/android/PlaybackService.java
+++ b/app/src/main/java/org/dharmaseed/android/PlaybackService.java
@@ -106,7 +106,7 @@ public class PlaybackService extends MediaSessionService {
             if (item != null && player.getPlaybackState() != Player.STATE_IDLE) {
                 final int talkID = Integer.parseInt(item.mediaId);
                 final double progress = player.getCurrentPosition() / (1000 * 60.0);
-                SimpleDateFormat parser = new SimpleDateFormat(PlayTalkActivity.DATE_FORMAT);
+                SimpleDateFormat parser = new SimpleDateFormat(Talk.DATE_FORMAT);
                 final String now = parser.format(GregorianCalendar.getInstance().getTime());
                 DBManager.getInstance(this).setTalkProgress(talkID, now, progress);
             }

--- a/app/src/main/java/org/dharmaseed/android/Talk.java
+++ b/app/src/main/java/org/dharmaseed/android/Talk.java
@@ -77,7 +77,7 @@ public class Talk {
             talk.id = talkID;
             talk.context = context;
 
-            setExtraTeachers(dbManager, talk);
+            talk.setExtraTeachers(dbManager);
 
         } else {
             Log.e(LOG_TAG, "Could not look up talk, id=" + talkID);
@@ -136,7 +136,7 @@ public class Talk {
         return db.rawQuery(query, null);
     }
 
-    private static void setExtraTeachers(DBManager dbManager, Talk talk) {
+    public void setExtraTeachers(DBManager dbManager) {
         SQLiteDatabase db = dbManager.getReadableDatabase();
         String query = String.format(
                 "SELECT %s.%s FROM %s, %s WHERE %s.%s=%s.%s AND %s.%s=%s",
@@ -155,14 +155,15 @@ public class Talk {
 
                 DBManager.C.TalkTeachers.TABLE_NAME,
                 DBManager.C.TalkTeachers.TALK_ID,
-                talk.id
+                id
         );
 
         Cursor cursor = db.rawQuery(query, null);
         while (cursor.moveToNext()) {
-            talk.getAllTeacherNames().add(
-                    cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.NAME)).trim()
-            );
+            String teacherName = cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.NAME)).trim();
+            if (!allTeacherNames.contains(teacherName)) {
+                allTeacherNames.add(teacherName);
+            }
         }
         cursor.close();
     }
@@ -201,12 +202,8 @@ public class Talk {
         return teacherName;
     }
 
-    public ArrayList<String> getAllTeacherNames() {
-        return allTeacherNames;
-    }
-
     // Return a comma-separated list of all teachers for this talk as a single string, with the primary teacher first
-    public String getAllTeacherNamesString() {
+    public String getAllTeacherNames() {
         // Make sure to list the primary teacher first
         String allTeachers = teacherName;
         for (String teacher : allTeacherNames) {

--- a/app/src/main/java/org/dharmaseed/android/Talk.java
+++ b/app/src/main/java/org/dharmaseed/android/Talk.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 public class Talk {
 
     private static final String LOG_TAG = "Talk";
+    protected static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
     private String title;
     private String description;
@@ -190,7 +191,7 @@ public class Talk {
 
     public String getDate() {
         try {
-            SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            SimpleDateFormat parser = new SimpleDateFormat(DATE_FORMAT);
             return DateFormat.getDateInstance().format(parser.parse(date));
         } catch (ParseException e) {
             Log.w(LOG_TAG, "Could not parse talk date for talk ID " + id);

--- a/app/src/main/java/org/dharmaseed/android/Talk.java
+++ b/app/src/main/java/org/dharmaseed/android/Talk.java
@@ -145,23 +145,23 @@ public class Talk {
 
                 // FROM
                 DBManager.C.Teacher.TABLE_NAME,
-                AbstractDBManager.C.TalkTeachers.TABLE_NAME,
+                DBManager.C.TalkTeachers.TABLE_NAME,
 
                 // WHERE
                 DBManager.C.Teacher.TABLE_NAME,
                 DBManager.C.Teacher.ID,
-                AbstractDBManager.C.TalkTeachers.TABLE_NAME,
-                AbstractDBManager.C.TalkTeachers.TEACHER_ID,
+                DBManager.C.TalkTeachers.TABLE_NAME,
+                DBManager.C.TalkTeachers.TEACHER_ID,
 
-                AbstractDBManager.C.TalkTeachers.TABLE_NAME,
-                AbstractDBManager.C.TalkTeachers.TALK_ID,
+                DBManager.C.TalkTeachers.TABLE_NAME,
+                DBManager.C.TalkTeachers.TALK_ID,
                 talk.id
         );
 
         Cursor cursor = db.rawQuery(query, null);
         while (cursor.moveToNext()) {
             talk.getAllTeacherNames().add(
-                    cursor.getString(cursor.getColumnIndexOrThrow(AbstractDBManager.C.Teacher.NAME)).trim()
+                    cursor.getString(cursor.getColumnIndexOrThrow(DBManager.C.Teacher.NAME)).trim()
             );
         }
         cursor.close();

--- a/app/src/main/java/org/dharmaseed/android/Talk.java
+++ b/app/src/main/java/org/dharmaseed/android/Talk.java
@@ -165,6 +165,7 @@ public class Talk {
                     cursor.getString(cursor.getColumnIndexOrThrow(AbstractDBManager.C.Teacher.NAME)).trim()
             );
         }
+        cursor.close();
     }
 
     public String getTitle() {

--- a/app/src/main/java/org/dharmaseed/android/Talk.java
+++ b/app/src/main/java/org/dharmaseed/android/Talk.java
@@ -6,7 +6,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.text.format.DateUtils;
 import android.util.Log;
 
-import java.io.File;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -26,7 +25,7 @@ public class Talk {
     private String audioUrl;
     private String date;
     private String teacherName;
-    private ArrayList<String> extraTeacherNames;
+    private ArrayList<String> allTeacherNames;
     private String centerName;
     private String photoFileName;
     private String path; // where the talk is downloaded, if it is
@@ -41,7 +40,7 @@ public class Talk {
     private double durationInMinutes;
 
     public Talk() {
-        extraTeacherNames = new ArrayList<>();
+        allTeacherNames = new ArrayList<>();
     }
 
     /**
@@ -146,22 +145,22 @@ public class Talk {
 
                 // FROM
                 DBManager.C.Teacher.TABLE_NAME,
-                DBManager.C.ExtraTalkTeachers.TABLE_NAME,
+                AbstractDBManager.C.TalkTeachers.TABLE_NAME,
 
                 // WHERE
                 DBManager.C.Teacher.TABLE_NAME,
                 DBManager.C.Teacher.ID,
-                DBManager.C.ExtraTalkTeachers.TABLE_NAME,
-                DBManager.C.ExtraTalkTeachers.TEACHER_ID,
+                AbstractDBManager.C.TalkTeachers.TABLE_NAME,
+                AbstractDBManager.C.TalkTeachers.TEACHER_ID,
 
-                DBManager.C.ExtraTalkTeachers.TABLE_NAME,
-                DBManager.C.ExtraTalkTeachers.TALK_ID,
+                AbstractDBManager.C.TalkTeachers.TABLE_NAME,
+                AbstractDBManager.C.TalkTeachers.TALK_ID,
                 talk.id
         );
 
         Cursor cursor = db.rawQuery(query, null);
         while (cursor.moveToNext()) {
-            talk.getExtraTeacherNames().add(
+            talk.getAllTeacherNames().add(
                     cursor.getString(cursor.getColumnIndexOrThrow(AbstractDBManager.C.Teacher.NAME)).trim()
             );
         }
@@ -202,15 +201,20 @@ public class Talk {
         return teacherName;
     }
 
-    public ArrayList<String> getExtraTeacherNames() {
-        return extraTeacherNames;
+    public ArrayList<String> getAllTeacherNames() {
+        return allTeacherNames;
     }
 
     // Return a comma-separated list of all teachers for this talk as a single string, with the primary teacher first
-    public String getAllTeachers() {
+    public String getAllTeacherNamesString() {
+        // Make sure to list the primary teacher first
         String allTeachers = teacherName;
-        for (String teacher : extraTeacherNames) {
-            allTeachers += ", " + teacher;
+        for (String teacher : allTeacherNames) {
+            // The primary teacher will also be listed in allTeacherNames, so skip it here
+            // so we don't include it twice
+            if (!teacher.equals(teacherName)) {
+                allTeachers += ", " + teacher;
+            }
         }
         return allTeachers;
     }

--- a/app/src/main/java/org/dharmaseed/android/Talk.java
+++ b/app/src/main/java/org/dharmaseed/android/Talk.java
@@ -3,9 +3,13 @@ package org.dharmaseed.android;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.text.format.DateUtils;
 import android.util.Log;
 
 import java.io.File;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 
 /**
@@ -41,8 +45,10 @@ public class Talk {
     }
 
     /**
-     * Create the object by setting all model values from the cursor
-     * @param cursor the result from the DB
+     * Create a talk object by setting all model values from the database
+     * @param dbManager The database manager
+     * @param context Application context
+     * @param talkID talk ID
      */
     public static Talk lookup(DBManager dbManager, Context context, int talkID) {
         Talk talk = null;
@@ -177,8 +183,18 @@ public class Talk {
         return durationInMinutes;
     }
 
+    public String getFormattedDuration() {
+        return DateUtils.formatElapsedTime((long)(durationInMinutes*60));
+    }
+
     public String getDate() {
-        return date;
+        try {
+            SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            return DateFormat.getDateInstance().format(parser.parse(date));
+        } catch (ParseException e) {
+            Log.w(LOG_TAG, "Could not parse talk date for talk ID " + id);
+            return date;
+        }
     }
 
     public String getTeacherName() {
@@ -187,6 +203,15 @@ public class Talk {
 
     public ArrayList<String> getExtraTeacherNames() {
         return extraTeacherNames;
+    }
+
+    // Return a comma-separated list of all teachers for this talk as a single string, with the primary teacher first
+    public String getAllTeachers() {
+        String allTeachers = teacherName;
+        for (String teacher : extraTeacherNames) {
+            allTeachers += ", " + teacher;
+        }
+        return allTeachers;
     }
 
     public String getCenterName() {

--- a/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
@@ -40,11 +40,8 @@ import java.text.SimpleDateFormat;
 
 public class TalkCursorAdapter extends StarCursorAdapter {
 
-    private SimpleDateFormat parser;
-
     public TalkCursorAdapter(DBManager dbManager, NavigationActivity context, int layout, Cursor c) {
         super(dbManager, DBManager.C.TalkStars.TABLE_NAME, context, layout, c);
-        parser = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     }
 
     @Override
@@ -60,29 +57,24 @@ public class TalkCursorAdapter extends StarCursorAdapter {
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
 
+        final int talkID = cursor.getInt(cursor.getColumnIndexOrThrow(DBManager.C.Talk.ID));
+        final Talk talk = Talk.lookup(dbManager, context, talkID);
+
         // Set talk title and teacher name
-        TextView title=(TextView)view.findViewById(R.id.item_view_title);
-        TextView teacher=(TextView)view.findViewById(R.id.item_view_detail1);
-        TextView center=(TextView)view.findViewById(R.id.item_view_detail2);
-        title.setText(getString(cursor, DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.TITLE));
-        teacher.setText(getString(cursor, DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.NAME));
-        center.setText(getString(cursor, DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Teacher.NAME));
+        final TextView title=(TextView)view.findViewById(R.id.item_view_title);
+        final TextView teacher=(TextView)view.findViewById(R.id.item_view_detail1);
+        final TextView center=(TextView)view.findViewById(R.id.item_view_detail2);
+        title.setText(talk.getTitle());
+        teacher.setText(talk.getAllTeachers());
+        center.setText(talk.getCenterName());
 
         // Set date
-        TextView date=(TextView)view.findViewById(R.id.item_view_detail3);
-        String recDate = getString(cursor, DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.RECORDING_DATE);
-        try {
-            date.setText(DateFormat.getDateInstance().format(parser.parse(recDate)));
-        } catch(ParseException e) {
-            date.setText("");
-        }
+        final TextView date=(TextView)view.findViewById(R.id.item_view_detail3);
+        date.setText(talk.getDate());
 
         // Set the talk duration
         final TextView durationView = (TextView)view.findViewById(R.id.item_view_detail4);
-        double duration = cursor.getDouble(cursor.getColumnIndexOrThrow(
-                DBManager.getAlias(DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.DURATION_IN_MINUTES)));
-        String durationStr = DateUtils.formatElapsedTime((long)(duration*60));
-        durationView.setText(durationStr);
+        durationView.setText(talk.getFormattedDuration());
 
         // Set teacher photo
         String photoFilename = DBManager.getTeacherPhotoFilename(cursor.getInt(cursor.getColumnIndexOrThrow(
@@ -97,12 +89,9 @@ public class TalkCursorAdapter extends StarCursorAdapter {
             photoView.setImageDrawable(icon);
         }
 
-        // get talk ID from cursor
-        final int talkID = cursor.getInt(cursor.getColumnIndexOrThrow(DBManager.C.Talk.ID));
-
         // Show talk progress
         ProgressBar talk_progress = (ProgressBar) view.findViewById(R.id.item_view_progress);
-        int duration_s = (int) (60*duration);
+        int duration_s = (int) (60*talk.getDurationInMinutes());
         int progress_s = (int) (60*dbManager.getTalkProgress(talkID));
         if (progress_s > 0) {
             talk_progress.setMax(duration_s);

--- a/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
@@ -24,7 +24,7 @@ import android.database.Cursor;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
 import androidx.core.content.ContextCompat;
-import android.text.format.DateUtils;
+
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -32,11 +32,7 @@ import android.widget.TextView;
 import android.widget.ProgressBar;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 
 public class TalkCursorAdapter extends StarCursorAdapter {
 
@@ -65,7 +61,7 @@ public class TalkCursorAdapter extends StarCursorAdapter {
         final TextView teacher=(TextView)view.findViewById(R.id.item_view_detail1);
         final TextView center=(TextView)view.findViewById(R.id.item_view_detail2);
         title.setText(talk.getTitle());
-        teacher.setText(talk.getAllTeachers());
+        teacher.setText(talk.getAllTeacherNamesString());
         center.setText(talk.getCenterName());
 
         // Set date

--- a/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkCursorAdapter.java
@@ -61,7 +61,7 @@ public class TalkCursorAdapter extends StarCursorAdapter {
         final TextView teacher=(TextView)view.findViewById(R.id.item_view_detail1);
         final TextView center=(TextView)view.findViewById(R.id.item_view_detail2);
         title.setText(talk.getTitle());
-        teacher.setText(talk.getAllTeacherNamesString());
+        teacher.setText(talk.getAllTeacherNames());
         center.setText(talk.getCenterName());
 
         // Set date

--- a/app/src/main/java/org/dharmaseed/android/TalkFetcherTask.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkFetcherTask.java
@@ -80,9 +80,7 @@ public class TalkFetcherTask extends DataFetcherTask {
                 ContentValues values = new ContentValues();
                 values.put(DBManager.C.TalkTeachers.TALK_ID, talkID);
                 values.put(DBManager.C.TalkTeachers.TEACHER_ID, teacherID);
-                db.insertWithOnConflict(DBManager.C.TalkTeachers.TABLE_NAME,
-                        null, values, SQLiteDatabase.CONFLICT_REPLACE);
-
+                db.insert(DBManager.C.TalkTeachers.TABLE_NAME,null, values);
             }
         }
     }

--- a/app/src/main/java/org/dharmaseed/android/TalkFetcherTask.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkFetcherTask.java
@@ -21,7 +21,6 @@ package org.dharmaseed.android;
 
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
-import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -71,24 +70,18 @@ public class TalkFetcherTask extends DataFetcherTask {
             // First, clear any existing entries for this talk, so that if any teachers are ever
             // removed from a talk after the talk is already added, we'll pick up that change
             // in the database.
-            dbManager.deleteID(talkID, AbstractDBManager.C.ExtraTalkTeachers.TABLE_NAME);
+            dbManager.deleteID(talkID, AbstractDBManager.C.TalkTeachers.TABLE_NAME);
 
             JSONArray teachersForTalk = talk.getJSONArray("teachers");
             for (int i = 0; i < teachersForTalk.length(); i++) {
                 int teacherID = teachersForTalk.getInt(i);
 
-                // Only store IDs for extra teachers (i.e. non-primary ones) in the extra_talk_teachers
-                // table. The primary teacher is already saved in the talk table.
-                if (teacherID != talk.getInt("teacher_id")) {
-                    Log.d(LOG_TAG, "Storing extra teacher ID " + teacherID + " for talk " + talkID);
-
-                    SQLiteDatabase db = dbManager.getWritableDatabase();
-                    ContentValues values = new ContentValues();
-                    values.put(AbstractDBManager.C.ExtraTalkTeachers.TALK_ID, talkID);
-                    values.put(AbstractDBManager.C.ExtraTalkTeachers.TEACHER_ID, teacherID);
-                    db.insertWithOnConflict(AbstractDBManager.C.ExtraTalkTeachers.TABLE_NAME,
-                            null, values, SQLiteDatabase.CONFLICT_REPLACE);
-                }
+                SQLiteDatabase db = dbManager.getWritableDatabase();
+                ContentValues values = new ContentValues();
+                values.put(AbstractDBManager.C.TalkTeachers.TALK_ID, talkID);
+                values.put(AbstractDBManager.C.TalkTeachers.TEACHER_ID, teacherID);
+                db.insertWithOnConflict(AbstractDBManager.C.TalkTeachers.TABLE_NAME,
+                        null, values, SQLiteDatabase.CONFLICT_REPLACE);
 
             }
         }

--- a/app/src/main/java/org/dharmaseed/android/TalkFetcherTask.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkFetcherTask.java
@@ -70,7 +70,7 @@ public class TalkFetcherTask extends DataFetcherTask {
             // First, clear any existing entries for this talk, so that if any teachers are ever
             // removed from a talk after the talk is already added, we'll pick up that change
             // in the database.
-            dbManager.deleteID(talkID, AbstractDBManager.C.TalkTeachers.TABLE_NAME);
+            dbManager.deleteID(talkID, DBManager.C.TalkTeachers.TABLE_NAME);
 
             JSONArray teachersForTalk = talk.getJSONArray("teachers");
             for (int i = 0; i < teachersForTalk.length(); i++) {
@@ -78,9 +78,9 @@ public class TalkFetcherTask extends DataFetcherTask {
 
                 SQLiteDatabase db = dbManager.getWritableDatabase();
                 ContentValues values = new ContentValues();
-                values.put(AbstractDBManager.C.TalkTeachers.TALK_ID, talkID);
-                values.put(AbstractDBManager.C.TalkTeachers.TEACHER_ID, teacherID);
-                db.insertWithOnConflict(AbstractDBManager.C.TalkTeachers.TABLE_NAME,
+                values.put(DBManager.C.TalkTeachers.TALK_ID, talkID);
+                values.put(DBManager.C.TalkTeachers.TEACHER_ID, teacherID);
+                db.insertWithOnConflict(DBManager.C.TalkTeachers.TABLE_NAME,
                         null, values, SQLiteDatabase.CONFLICT_REPLACE);
 
             }

--- a/app/src/main/java/org/dharmaseed/android/TalkRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkRepository.java
@@ -44,7 +44,7 @@ public class TalkRepository extends Repository {
             boolean isStarred,
             boolean isDownloaded
     ) {
-        return getTalks(talkAdapterColumns, searchTerms, isStarred, isDownloaded, "");
+        return getTalks(talkAdapterColumns, searchTerms, isStarred, isDownloaded, "", "");
     }
 
     /**
@@ -55,14 +55,16 @@ public class TalkRepository extends Repository {
      * @param isStarred    whether the talk is starred
      * @param isDownloaded whether the talk is downloaded
      * @param extraWhere   an extra where clause that can be used to filter on a specific teacher/center id
+     * @param extraInnerJoin an extra inner join clause that can be used to join with an extra table
      * @return every talk in the db filtered by search term, is starred, and is downloaded
      */
-    public Cursor getTalks(
+    private Cursor getTalks(
             List<String> columns,
             List<String> searchTerms,
             boolean isStarred,
             boolean isDownloaded,
-            String extraWhere
+            String extraWhere,
+            String extraInnerJoin
     ) {
         if (columns == null || columns.size() == 0) {
             throw new IllegalArgumentException("No columns were specified; at least one is required");
@@ -81,7 +83,7 @@ public class TalkRepository extends Repository {
 
         String query = "SELECT " + queryColumns + " FROM " + DBManager.C.Talk.TABLE_NAME;
 
-        String innerJoin = "";
+        String innerJoin = extraInnerJoin;
 
         boolean teachers = false, centers = false;
         if (queryColumns.contains(DBManager.C.Teacher.TABLE_NAME)) {
@@ -154,7 +156,7 @@ public class TalkRepository extends Repository {
             boolean isStarred,
             boolean isDownloaded
     ) {
-        return getTalks(columns, searchTerms, isStarred, isDownloaded, "");
+        return getTalks(columns, searchTerms, isStarred, isDownloaded, "", "");
     }
 
     /**
@@ -171,7 +173,8 @@ public class TalkRepository extends Repository {
             boolean isDownloaded
     ) {
         return getTalks(talkAdapterColumns, searchTerms, isStarred, isDownloaded,
-                DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.ID + "=" + teacherId);
+                DBManager.C.ExtraTalkTeachers.TABLE_NAME + "." + DBManager.C.ExtraTalkTeachers.TEACHER_ID + "=" + teacherId,
+                joinExtraTalkTeachers());
     }
 
     /**
@@ -188,7 +191,7 @@ public class TalkRepository extends Repository {
             boolean isDownloaded
     ) {
         return getTalks(talkAdapterColumns, searchTerms, isStarred, isDownloaded,
-                DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.ID + "=" + venueId);
+                DBManager.C.Center.TABLE_NAME + "." + DBManager.C.Center.ID + "=" + venueId, "");
     }
 
     /**
@@ -259,6 +262,13 @@ public class TalkRepository extends Repository {
         } finally {
             in.close();
         }
+    }
+
+     private String joinExtraTalkTeachers() {
+        return innerJoin(DBManager.C.ExtraTalkTeachers.TABLE_NAME,
+                DBManager.C.ExtraTalkTeachers.TABLE_NAME + "." + DBManager.C.ExtraTalkTeachers.TALK_ID,
+                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.ID
+                );
     }
 
     private String joinStarredTalks() {

--- a/app/src/main/java/org/dharmaseed/android/TalkRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkRepository.java
@@ -280,14 +280,13 @@ public class TalkRepository extends Repository {
 
     private String joinTalkTeachers() {
         return innerJoin(
+                DBManager.C.TalkTeachers.TABLE_NAME,
+                DBManager.C.TalkTeachers.TABLE_NAME + "." + DBManager.C.TalkTeachers.TALK_ID,
+                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.ID) +
+            innerJoin(
                 DBManager.C.Teacher.TABLE_NAME,
                 DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.ID,
-                DBManager.C.TalkTeachers.TABLE_NAME + "." + DBManager.C.TalkTeachers.TEACHER_ID) +
-                innerJoin(
-                        DBManager.C.TalkTeachers.TABLE_NAME,
-                        DBManager.C.TalkTeachers.TABLE_NAME + "." + DBManager.C.TalkTeachers.TALK_ID,
-                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.ID
-        );
+                DBManager.C.TalkTeachers.TABLE_NAME + "." + DBManager.C.TalkTeachers.TEACHER_ID);
     }
 
     private String joinTalkIdVenueId() {

--- a/app/src/main/java/org/dharmaseed/android/TalkRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkRepository.java
@@ -172,7 +172,7 @@ public class TalkRepository extends Repository {
             boolean isDownloaded
     ) {
         return getTalks(talkAdapterColumns, searchTerms, isStarred, isDownloaded,
-                AbstractDBManager.C.TalkTeachers.TABLE_NAME + "." + AbstractDBManager.C.TalkTeachers.TEACHER_ID + "=" + teacherId);
+                DBManager.C.TalkTeachers.TABLE_NAME + "." + DBManager.C.TalkTeachers.TEACHER_ID + "=" + teacherId);
     }
 
     /**

--- a/app/src/main/java/org/dharmaseed/android/TalkRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/TalkRepository.java
@@ -173,7 +173,7 @@ public class TalkRepository extends Repository {
             boolean isDownloaded
     ) {
         return getTalks(talkAdapterColumns, searchTerms, isStarred, isDownloaded,
-                DBManager.C.ExtraTalkTeachers.TABLE_NAME + "." + DBManager.C.ExtraTalkTeachers.TEACHER_ID + "=" + teacherId,
+                AbstractDBManager.C.TalkTeachers.TABLE_NAME + "." + AbstractDBManager.C.TalkTeachers.TEACHER_ID + "=" + teacherId,
                 joinExtraTalkTeachers());
     }
 
@@ -265,8 +265,8 @@ public class TalkRepository extends Repository {
     }
 
      private String joinExtraTalkTeachers() {
-        return innerJoin(DBManager.C.ExtraTalkTeachers.TABLE_NAME,
-                DBManager.C.ExtraTalkTeachers.TABLE_NAME + "." + DBManager.C.ExtraTalkTeachers.TALK_ID,
+        return innerJoin(AbstractDBManager.C.TalkTeachers.TABLE_NAME,
+                AbstractDBManager.C.TalkTeachers.TABLE_NAME + "." + AbstractDBManager.C.TalkTeachers.TALK_ID,
                 DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.ID
                 );
     }

--- a/app/src/main/java/org/dharmaseed/android/TeacherRepository.java
+++ b/app/src/main/java/org/dharmaseed/android/TeacherRepository.java
@@ -34,10 +34,10 @@ public class TeacherRepository extends Repository
 
     public Cursor getTeachers(List<String> searchTerms, boolean isStarred)
     {
-        String query = "SELECT teachers._id, teachers.name, count(talks._id) AS talk_count FROM teachers ";
+        String query = "SELECT teachers._id, teachers.name, count(talk_teachers._id) AS talk_count FROM teachers ";
         String innerJoin = innerJoin(
-                DBManager.C.Talk.TABLE_NAME,
-                DBManager.C.Talk.TABLE_NAME + "." + DBManager.C.Talk.TEACHER_ID,
+                DBManager.C.TalkTeachers.TABLE_NAME,
+                DBManager.C.TalkTeachers.TABLE_NAME + "." + DBManager.C.TalkTeachers.TEACHER_ID,
                 DBManager.C.Teacher.TABLE_NAME + "." + DBManager.C.Teacher.ID
         );
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
# Summary

Adds support for multiple teachers per talk, as indicated by the `teachers` field returned by the dharmaseed talks API.
* The talk detail view and mini-talk cards in the main navigation view now list all teachers associated with a talk. The primary teacher (i.e. the teacher given by `teacher_id` in the talk object) is always listed first, followed by any additional teachers. See screenshot 1.
* Searching for talks will now also search over the names of all teachers associated with a talk. See screenshot 2.
* The teacher detail view now shows all talks given by that teacher, including talks for which the teacher is not the primary teacher. See screenshot 3.

# Screenshots

![Screenshot_20231212-163713](https://github.com/dharmaseed/dharmaseed-android/assets/10068296/ee0742a7-d4a9-4639-806d-a2d3cd8398b1)
![Screenshot_20231212-163810](https://github.com/dharmaseed/dharmaseed-android/assets/10068296/c1a59400-f6ee-4bb1-9062-4ffb1d8f6aeb)
![Screenshot_20231212-163854](https://github.com/dharmaseed/dharmaseed-android/assets/10068296/7833485e-2465-4e54-8c8a-e6647c7f93e2)

# Notes

This PR adds a new table, `talk_teachers`, to hold the many-to-many association between teachers and talks. @intermarc's new feature for rolling out database schema changes came in very handy for this!

There were some opportunities to clean up and refactor some of our database query code as part of this PR, so I went ahead and did that. I've also updated our database unit tests to include tests for the new functionality added in this PR.

# Related issues

Along with #90 and #93, this PR fully closes #89.