### PR TITLE
"App Not Responding" Fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdk 21
         compileSdk 34
         targetSdk 34
-        versionCode 28
-        versionName "1.6.0"
+        versionCode 29
+        versionName "1.6.1"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdk 21
         compileSdk 34
         targetSdk 34
-        versionCode 29
-        versionName "1.6.1"
+        versionCode 30
+        versionName "1.6.2"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,12 +47,13 @@ dependencies {
     implementation 'com.google.android.material:material:1.10.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.2'
 
-    // Exoplayer stuff
-    implementation 'androidx.media3:media3-exoplayer:1.2.0'
-    implementation 'androidx.media3:media3-ui:1.2.0'
-    implementation "androidx.media3:media3-session:1.2.0"
+    // UI stuff
+    implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    // Exoplayer stuff
+    implementation 'androidx.media3:media3-exoplayer:1.3.0'
+    implementation 'androidx.media3:media3-ui:1.3.0'
+    implementation "androidx.media3:media3-session:1.3.0"
 
     // Required for instrumented tests
     androidTestImplementation 'androidx.test:core:1.5.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,7 @@ android {
         minSdk 21
         compileSdk 34
         targetSdk 34
-        versionCode 30
+        versionCode 31
         versionName "1.6.2"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/app/src/main/java/org/dharmaseed/android/PlaybackService.java
+++ b/app/src/main/java/org/dharmaseed/android/PlaybackService.java
@@ -125,6 +125,16 @@ public class PlaybackService extends MediaSessionService {
         mediaSession = null;
     }
 
+    @Override
+    public void onTaskRemoved(@Nullable Intent rootIntent) {
+        Player player = mediaSession.getPlayer();
+        if (player.getPlayWhenReady()) {
+            // Make sure the service is not in foreground.
+            player.pause();
+        }
+        stopSelf();
+    }
+
     @Nullable
     @Override
     public MediaSession onGetSession(MediaSession.ControllerInfo controllerInfo) {

--- a/app/src/main/java/org/dharmaseed/android/PlaybackService.java
+++ b/app/src/main/java/org/dharmaseed/android/PlaybackService.java
@@ -127,6 +127,8 @@ public class PlaybackService extends MediaSessionService {
 
     @Override
     public void onTaskRemoved(@Nullable Intent rootIntent) {
+        // Stop the MediaSessionService when the app is closed in the background
+        // (work around broken notification issue)
         Player player = mediaSession.getPlayer();
         if (player.getPlayWhenReady()) {
             // Make sure the service is not in foreground.

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="@dimen/mini_player_height"
     android:orientation="horizontal"
+    android:visibility="gone"
     tools:context=".MiniPlayerFragment">
 
     <ImageView


### PR DESCRIPTION
This merge pulls in changes that were made to fix the "App Not Responding" issues that we have been seeing in production. Apart from updating to the latest release of the media3 library, the changes concern two ways in which the new `PlaybackService` works.

**Retrieval of the MediaController**
Our ANR problem has been discussed in [this](https://github.com/androidx/media/issues/890) open issue. There was a very helpful response regarding what might be done. In particular, the suggestions were:

1. Using `Futures.addCallback()` instead of `controllerFuture.addListener()`
2. Using `MoreExecutors.directExecutor()` instead of `ContextCompat.getMainExecutor()`

Both of these were implemented in 403c480eedd9877af46bf1e8b3090336aa9aa143

**Stopping the `MediaSessionService` when the app is killed in the background**
Another potential source of ANRs and crashes was described in [this issue](https://github.com/androidx/media/issues/805), which applies to our app as well. I've also been able to reproduce a similar and perhaps directly related issue on a phone running an older version of android (see the video in #99).

To limit the scope of the changes in this pull request, I've opted for the simple solution of ending the `MediaSessionService` when the app is closed in the background (see c98006402056faaca9880c7b21f7fe86f4535c8c). With this change, the media notification no longer "hangs around" when the app is stopped in the background, thereby preventing this kind of issue.

The disadvantage of this approach is that the media notification is gone and the user has to explicitly re-start the app and find the right talk to continue listening. I've created the branch `playback_resumption` to implement a more satisfactory solution (following the [official documentation](https://developer.android.com/media/media3/session/background-playback#resumption)).