### PR TITLE
Add seek back/forward buttons to system media notification

### DIFF
--- a/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/PlayTalkActivity.java
@@ -77,6 +77,7 @@ public class PlayTalkActivity extends AppCompatActivity
     Talk talk;
 
     static final String LOG_TAG = "PlayTalkActivity";
+    public static final int SEEK_AMOUNT_MS = 15000;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -409,11 +410,11 @@ public class PlayTalkActivity extends AppCompatActivity
     }
 
     public void fastForwardButtonClicked(View view) {
-        setTalkProgress(getTalkProgress() + 15000);
+        setTalkProgress(getTalkProgress() + SEEK_AMOUNT_MS);
     }
 
     public void rewindButtonClicked(View view) {
-        setTalkProgress(getTalkProgress() - 15000);
+        setTalkProgress(getTalkProgress() - SEEK_AMOUNT_MS);
     }
 
     @Override

--- a/app/src/main/res/drawable/ic_seek_back.xml
+++ b/app/src/main/res/drawable/ic_seek_back.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="20dp"
+    android:viewportWidth="16"
+    android:viewportHeight="20">
+
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:pathData="M5 5h3c3.866 0 7 3.134 7 7s-3.134 7-7 7-7-3.134-7-7 " />
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:pathData="M7.5 8.5L4 5l3.5-3.5 " />
+</vector>

--- a/app/src/main/res/drawable/ic_seek_forward.xml
+++ b/app/src/main/res/drawable/ic_seek_forward.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="20dp"
+    android:viewportWidth="16"
+    android:viewportHeight="20">
+
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:pathData="M11 5H8c-3.866 0-7 3.134-7 7s3.134 7 7 7 7-3.134 7-7 " />
+    <path
+        android:strokeColor="#000000"
+        android:strokeWidth="2"
+        android:strokeLineCap="round"
+        android:pathData="M8.5 8.5L12 5 8.5 1.5 " />
+</vector>


### PR DESCRIPTION
It's bugged me that the app's media notification doesn't have buttons to skip back/forward in the talks. I was digging around and found @bb4242's PR note linking to MediaSession custom layout examples. After a lot of head scratching and trials and errors I was able to get custom buttons working. A few rabbit holes later, I figured out how to turn off the "seek to beginning of track" button too, which shifts "skip back" over to the left of seek bar:

![Screenshot_20250312-215315](https://github.com/user-attachments/assets/fd09ae6a-8bb5-4e92-b564-115a54fde067)

### Design

I like the placement of "skip back" on left and "skip forward" on right, it seems natural to separate them with the seek bar in between. Pocket Casts has this same button layout, with 2 additional custom buttons to the right - I think they got it right so wanted to emulate it : )

I feel like if "skip back" is present there's no need for the "restart track" button. Rearranging the buttons this way also activated a media notif feature I've never noticed - while dragging on the seek bar, it replaces the left icon with the seek time and the right icon with the total track time (at least on Android 15), I thought this was pretty cool.

![Screenshot_20250312-214854~2](https://github.com/user-attachments/assets/91251bd9-3401-49b4-b98e-8c4c329101ea)

Buttons in the mini version of the media notif also work well:

![Screenshot_20250312-215914_Dharma_Seed](https://github.com/user-attachments/assets/d20db1d0-4d3c-441f-9e04-7a956e6f0694)

### Testing

Tested with Android 15 on Pixel 8 and Zenfone 10, both API Level 35. I've been pressing the buttons on Pixel 8 for a few talks over the past couple days with no issues.

Oldest emulator I could get working in Android Studio is Android 8, API Level 26. Buttons look and work OK on there:

![Screenshot_20250312_223436](https://github.com/user-attachments/assets/04a8a770-63c2-4584-95f3-77207312e1b7)

Tried a couple other API levels in between with the emulator and didn't find any issues with those.

I hate to be the person who submits their first PR without getting tests running, but I couldn't get tests running! Getting the error "Execution failed for task ':app:connectedDebugAndroidTest'". I looked through the tests though nothing seemed to be calling playback code.

This is my 1st Android dev adventure so I'm not too familiar with media3 or the overall system workings. But from reading issues/PRs/comments it seems there's a lot of gotchas with tracking play state and media3 quirks. I tested the best I could, hoping this wouldn't cause any issues but I'm not totally confident so needs review.

### Code notes

- Moved hardcoded 15000 ms seek time into a PlayTalkActivity static var that's imported by PlaybackService, so seek lengths remain linked
- Built Exoplayer with setSeekBackIncrementMs() and setSeekForwardIncrementMs(), so the buttons simply have to call session.getPlayer().seekBack() / seekForward(). This seems to behave OK at the talk start/end, without the need for explicit calcs like in PlayTalkActivity.setTalkProgress()
- I didn't see an obvious way to unify seek functionality from PlayTalkActivity.setTalkProgress() which has a MediaController, with the PlaybackService.onCustomCommand() which has a MediaSession. But perhaps there is an easy way I'm missing?

### The Icons
- <img width="40" src="https://github.com/user-attachments/assets/503a8fd1-c3a0-40f7-b358-91747f83cf18" /> <img width="40" src="https://github.com/user-attachments/assets/5a04b18b-e139-491e-beb4-7317960b84fd" />
- Most audiobook, podcast, and dharma apps have consolidated around this circle icon design language for skipping around in the track (Pocket Casts, Spotify + Apple podcasts, Google Play Books, Waking Up) and I noticed the current iOS Dharma Seed app uses them as well. I know the Play Talk page uses the ⏪ ⏩ icons but I think they are kinda dated at this point, so I wanted to present these as an option and open the conversation to potential future Play Talk UI improvements too.

Thx for the consideration,
Dan