### PR TITLE
Refresh navigation intent

### DIFF
--- a/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
@@ -320,12 +320,12 @@ public class NavigationActivity extends AppCompatActivity
         setIntendedView(getIntent());
     }
 
-    protected void setIntendedView(Intent i) {
-        Log.d(LOG_TAG, "Intent with type=" + i.getType() + " action="+i.getAction() + " data="+i.getData());
+    protected void setIntendedView(Intent intent) {
+        Log.d(LOG_TAG, "Intent with type=" + intent.getType() + " action="+intent.getAction() + " data="+intent.getData());
 
         ViewMode vm = new ViewMode(ViewMode.VIEW_MODE_TALKS);
 
-        Uri intentURI = i.getData();
+        Uri intentURI = intent.getData();
         if (intentURI != null) {
             java.util.List<String> segments = intentURI.getPathSegments();
 

--- a/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
+++ b/app/src/main/java/org/dharmaseed/android/NavigationActivity.java
@@ -245,6 +245,9 @@ public class NavigationActivity extends AppCompatActivity
         talkRepository = new TalkRepository(dbManager);
         teacherRepository = new TeacherRepository(dbManager);
         centerRepository = new CenterRepository(dbManager);
+
+        // initialize view and view history
+        viewHistory = new LinkedList();
         setIntendedView();
 
         // Set swipe refresh listener
@@ -307,9 +310,17 @@ public class NavigationActivity extends AppCompatActivity
         }
     }
 
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntendedView(intent);
+    }
+
     protected void setIntendedView() {
-        viewHistory = new LinkedList();
-        Intent i = getIntent();
+        setIntendedView(getIntent());
+    }
+
+    protected void setIntendedView(Intent i) {
         Log.d(LOG_TAG, "Intent with type=" + i.getType() + " action="+i.getAction() + " data="+i.getData());
 
         ViewMode vm = new ViewMode(ViewMode.VIEW_MODE_TALKS);


### PR DESCRIPTION
This update patches an open issue with App Link support. @bb4242 originally reported this issue in https://github.com/dharmaseed/dharmaseed-android/pull/107#issuecomment-2675803131:

> 4. I tried opening https://dharmaseed.org/teacher/229 as a link from a messaging app (Signal), and it opens to the expected teacher page. However, opening what I'm pretty sure is the same link from my web browser (i.e. while browsing dharmaseed.org in the browser, having searched for Greg Scharf on the teachers page) only opens the dharmaseed app to the regular talk navigation page, not the teacher page as I would have expected. I'm not sure why this is different.

I've now managed to reproduce this issue on standard Android. The problem occurs when a link is opened from the browser _and_ the app is already open in the background. Since the navigation activity has a `singleTop` launch mode, this means the running activity receives a new intent which must be dealt with in [`protected void onNewIntent (Intent intent)`](https://developer.android.com/reference/android/app/Activity.html#onNewIntent%28android.content.Intent%29). I missed this earlier because the issue only seems to arise when links are opened in the browser (as opposed to messenger apps such as Signal).