### PR TITLE
Don't close the database connection in DBManager.setTalkProgress()

### DIFF
--- a/app/src/main/java/org/dharmaseed/android/DBManager.java
+++ b/app/src/main/java/org/dharmaseed/android/DBManager.java
@@ -377,7 +377,6 @@ public class DBManager extends AbstractDBManager {
             Log.i(LOG_TAG, "Updated talk history item for talk "+id+"("+progress+" min)");
         }
         cursor.close();
-        db.close();
     }
 
     public boolean addDownload(Talk talk) {


### PR DESCRIPTION
Fixes #108; see the discussion there.

I tested this by following the helpful procedure reported in the initial bug report, and verifying that the bug goes away when this fix is applied. I also tested by enabling [StrictMode](https://github.com/dharmaseed/dharmaseed-android/blob/96558826cde8da91061e5ace29fb6f9e92b2291d/app/src/main/java/org/dharmaseed/android/NavigationActivity.java#L197) and using the app for a while to make sure we aren't leaking resources. I had initially thought we might need to call `db.close()` somewhere to properly clean up the database connection, but I don't see any real indication that's necessary from these tests. And the fact that things apparently worked fine without such a `db.close()` call before the talk progress feature was added also lends support to the idea that we don't need to worry about that too much.